### PR TITLE
fix: resolve transport mismatch in dialback response (v1.7.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.10] - 2026-01-07
+
+### Fixed
+
+- **Transport**: Fixed transport mismatch where dialback responses were sent as raw UDP datagrams instead of signed `p2plib` messages (#20). Updated `sendMessage` to use high-level `_router.sendMessage` which ensures proper wrapping and signing, preventing packets from being dropped by the receiver's length checks.
+
 ## [1.7.9] - 2026-01-07
 
 ### Fixed

--- a/lib/src/transport/router_impl_io.dart
+++ b/lib/src/transport/router_impl_io.dart
@@ -325,16 +325,11 @@ class P2plibRouter {
     return connectedPeers;
   }
 
-  /// Sends a message to a peer.
-  Future<void> sendMessage(String peerIdStr, Uint8List message) {
+  /// Sends a message to a peer using p2plib's high-level messaging.
+  /// This ensures the message is correctly wrapped, signed, and encrypted.
+  Future<void> sendMessage(String peerIdStr, Uint8List message) async {
     final peer = p2p.PeerId(value: Base58().base58Decode(peerIdStr));
-    final addresses = _router.resolvePeerId(peer);
-    if (addresses.isEmpty) {
-      throw Exception('No addresses found for peer $peerIdStr');
-    }
-
-    _router.sendDatagram(addresses: addresses, datagram: message);
-    return Future.value();
+    await _router.sendMessage(dstId: peer, payload: message);
   }
 
   /// Receives messages from a specific peer.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
-name: dart_ipfs
+name:dart_ipfs
 description: Production-ready IPFS implementation in Dart with full protocol support, P2P networking, Gateway mode, and offline capabilities. Supports mobile (Flutter) and web platforms.
-version: 1.7.9
+version: 1.7.10
 homepage: https://github.com/jxoesneon/IPFS
 repository: https://github.com/jxoesneon/IPFS
 issue_tracker: https://github.com/jxoesneon/IPFS/issues


### PR DESCRIPTION
### Description
This PR resolves the dialback timeout issue by fixing a transport mismatch in the `P2plibRouter.sendMessage` implementation.

### Changes
- Updated `P2plibRouter.sendMessage` to use the high-level `_router.sendMessage` method from `p2plib` instead of raw `_router.sendDatagram`.
- This ensures all outgoing messages are correctly wrapped in signed `p2plib.Message` objects with headers, satisfying the receiver's length and signature checks.
- Bumps version to `1.7.10`.

### Related Issue
Fixes #20

### Verification
Local tests in the `SeedSphere` projects (`router` and `gardener`) have confirmed that this fix allows dialback responses to be correctly received, preventing timeouts and disconnections.