### PR TITLE
fix(bitswap): use correct protocol ID and track peers on connect

### DIFF
--- a/lib/src/protocols/bitswap/bitswap_handler.dart
+++ b/lib/src/protocols/bitswap/bitswap_handler.dart
@@ -217,7 +217,7 @@ class BitswapHandler {
     if (hasContent) {
       try {
         final messageBytes = outgoingMessage.toBytes();
-        await _router.sendMessage(fromPeer, messageBytes);
+        await _router.sendMessage(fromPeer, messageBytes, protocolId: _protocolId);
 
         // Update ledger stats
         final ledger = _ledgerManager.getLedger(fromPeer);
@@ -355,7 +355,8 @@ class BitswapHandler {
     for (final peerId in connectedPeers) {
       futures.add(
         Future(() {
-          _router.sendMessage(peerId, messageBytes);
+          _router.sendMessage(peerId, messageBytes,
+              protocolId: _protocolId);
           // print('Want request sent to peer: ${peer.toString()}');
         }).catchError((error) {
           // print(

--- a/lib/src/transport/libp2p_router.dart
+++ b/lib/src/transport/libp2p_router.dart
@@ -252,6 +252,7 @@ class Libp2pRouter implements RouterInterface {
       await _host!.connect(addrInfo);
 
       // _connectedPeers is updated via NotifyBundle in start()
+      _connectedPeers.add(peerIdStr);
       _logger.debug('Connected to peer $peerIdStr');
     } catch (e) {
       _logger.error('Failed to connect to $multiaddress', e);


### PR DESCRIPTION
## Problem                                                                       
                                                                                   
  Bitswap cannot exchange messages with other IPFS implementations (e.g., Kubo) due
   to two bugs:                                                                    
                                                                                   
  1. **Wrong outbound protocol ID.** `BitswapHandler` calls `_router.sendMessage()`
   without passing `protocolId`, so `Libp2pRouter.sendMessage()` defaults to
  `'/ipfs/1.0.0'` — a nonexistent protocol. The remote peer rejects the stream     
  during multistream-select negotiation. The handler registers the correct ID
  (`/ipfs/bitswap/1.2.0`) for *inbound* streams but never passes it on *outbound*
  calls.

  2. **Connected peers not tracked.** After a successful outbound `connect()`, the 
  peer is not added to `_connectedPeers`. The `NotifyBundle.connectedF` callback
  registered in `start()` is supposed to handle this, but it does not fire for     
  outbound connections in `ipfs_libp2p` 0.5.6. As a result, 
  `_broadcastWantRequest()` always sees zero peers and throws `StateError('No
  connected peers')`, which `wantBlock()` catches and returns null.

  ## Fix

  - Pass `protocolId: _protocolId` on both `sendMessage` call sites in             
  `BitswapHandler` (lines 220 and 358).
  - Explicitly add the peer ID to `_connectedPeers` after `_host!.connect()`       
  succeeds in `Libp2pRouter.connect()`.                                            
   
  ## Verified                                                                      
                                                            
  - `dart analyze` clean on both files.
  - Full test suite passes (1098/1098).
  - Tested locally against Kubo 0.40.1: Dart node connects, sends Bitswap want
  request, Kubo responds with the block, and the Bitswap stream negotiates         
  `/ipfs/bitswap/1.2.0` successfully in both directions.
                                                                                   
  Note: additional fixes are needed in `Message.fromBytes()` and `Block.validate()`
   to complete end-to-end block delivery — those will be in follow-up PRs.