### PR TITLE
fix(bitswap): surface errors in async packet handler

### DIFF
--- a/lib/src/protocols/bitswap/bitswap_handler.dart
+++ b/lib/src/protocols/bitswap/bitswap_handler.dart
@@ -371,11 +371,15 @@ class BitswapHandler {
   // Removed _getPeerAddress as it's no longer needed with new Router API
 
   Future<void> _handlePacket(NetworkPacket packet) async {
-    final msg = await message.Message.fromBytes(packet.datagram);
-    // Annotate message with sender
-    msg.from = packet.srcPeerId;
-
-    await _handleMessage(msg);
+    try {
+      final msg = await message.Message.fromBytes(packet.datagram);
+      // Annotate message with sender
+      msg.from = packet.srcPeerId;
+      await _handleMessage(msg);
+    } catch (e, st) {
+      _logger.error('Failed to handle Bitswap packet from ${packet.srcPeerId}: $e');
+      _logger.error('$st');
+    }
   }
 
   /// Handles an incoming want request for a CID.


### PR DESCRIPTION
## Problem                                                                       
                                                                                   
  `_handlePacket` is an `async` method but the router calls it without `await`     
  (fire-and-forget). Any exception thrown during message parsing or handling       
  becomes an unhandled Future rejection that is silently dropped. This makes       
  Bitswap failures invisible — no log, no error, no indication that anything went
  wrong.

  ## Fix

  Wrap the body of `_handlePacket` in a try/catch that logs the error and stack    
  trace via the existing `_logger`.
                                                                                   
  ## Verified                                               

  - `dart analyze` clean.                                                          
  - Full test suite passes (1098/1098).
  - No behavior change for the success path.                                       
                                                                                   
  Part of a series with #27 and #28 to fix Bitswap interop with Kubo.