### PR TITLE
docs+test: flag PubSub message tag as non-authenticating (SEC-008)

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,7 +644,7 @@ The node uses the following algorithms and parameters:
 | Salt | 16 bytes | Generated randomly if not supplied |
 | Peer identity keys | Ed25519 | 32-byte seeds / public keys |
 | IPNS records | Ed25519 signatures | With expiration timestamps |
-| PubSub messages | HMAC-SHA256 signing | Per `SECURITY.md` |
+| PubSub messages | HMAC-SHA256 tag | **Not an authenticity signature** — the HMAC key is the message's own public `sender` field, so the tag is reproducible by anyone and only guards against accidental corruption/dedup, not spoofing. See `PubSubClient`'s class-level doc comment and `SECURITY.md`. |
 | Hashing | SHA-256 | Used for CIDs, PeerID derivation, and PoW checks |
 
 ### Recommended Deployment

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -50,7 +50,7 @@ This project implements the following security measures:
 
 - **Block Validation:** CID hash verification on all received blocks
 - **IPNS Records:** Ed25519 signatures with expiration timestamps
-- **PubSub:** HMAC-SHA256 message signing
+- **PubSub:** HMAC-SHA256 message tag for integrity/dedup only. This does **not** authenticate the sender: the HMAC key is derived from the message's own public `sender` field, so the tag is reproducible by any party without a secret. Tracked as a known limitation (see `PubSubClient`'s class-level doc comment) — a real fix needs asymmetric Ed25519 signing plus a peer public-key registry.
 
 ## Dependency Security
 

--- a/lib/src/protocols/pubsub/pubsub_client.dart
+++ b/lib/src/protocols/pubsub/pubsub_client.dart
@@ -15,12 +15,38 @@ import 'pubsub_message.dart';
 
 /// Handles PubSub operations for an IPFS node with Gossipsub-like features.
 ///
-/// Implements message propagation, peer mesh maintenance, and message signing
-/// to ensure authenticity and prevent spoofing.
+/// Implements message propagation, peer mesh maintenance, and message
+/// tagging via [_computeSignature].
 ///
-/// **Security (SEC-008):** All outgoing messages are signed with HMAC-SHA256
-/// using the sender's PeerID as the key. Incoming messages are verified
-/// against this signature.
+/// **Security (SEC-008) — KNOWN LIMITATION, NOT AN AUTHENTICITY GUARANTEE:**
+/// Outgoing messages carry an HMAC-SHA256 tag computed with the sender's own
+/// PeerID string as the HMAC key. Because the PeerID is public by design
+/// (it is meant to be shared so other nodes can dial the peer) and is
+/// re-transmitted in cleartext in the very same message as the `sender`
+/// field, this "signature" is **not** a secret-backed MAC: any party can
+/// recompute the identical tag for any sender + any content using only
+/// information the message itself discloses. It does **not** prevent
+/// message spoofing/impersonation and must not be relied on as an
+/// authenticity or anti-spoofing control — despite being described that way
+/// in earlier revisions of this file, README.md, and SECURITY.md. Treat it
+/// as a message-integrity/dedup tag only (it does catch accidental bit
+/// corruption and lets peers dedupe by tag), not as proof of who sent a
+/// message.
+///
+/// A real fix needs asymmetric signing: sign with the sender's actual
+/// Ed25519 identity private key (already obtainable via
+/// `SecurityManager.getSecureKey()`) and verify against that peer's known
+/// Ed25519 *public* key. That public key cannot be derived from the PeerID
+/// in this codebase — [PeerId.fromPublicKey] hashes it with SHA-256, which
+/// is one-way — so verification additionally needs a peer public-key
+/// registry populated when peers are first seen (e.g. from the Identify
+/// protocol response in `IdentifyHandler`, which currently sends this
+/// node's own public key but does not appear to persist a received peer's
+/// public key anywhere lookup-able). A correct, spec-compliant Ed25519
+/// signer already exists at
+/// `lib/src/protocols/pubsub/gossipsub/message_signing.dart`
+/// (`Ed25519MessageSigner`) but is not wired into this class or into the
+/// default `PubSubHandler` construction path.
 class PubSubClient implements IPubSub {
   /// Creates a [PubSubClient] with the provided [_router] and peer identifier.
   ///
@@ -124,7 +150,11 @@ class PubSubClient implements IPubSub {
         return;
       }
 
-      // SEC-008: Verify message signature for authenticity
+      // SEC-008: This only checks that the tag matches _computeSignature's
+      // output; since that function's "key" is the public sender field
+      // carried in this same message, this rejects corrupted/mismatched
+      // tags but does NOT authenticate that `sender` actually sent this
+      // message. See the class-level doc comment above for details.
       final String? signature = msgMap['signature'] as String?;
       if (signature != null) {
         final String expectedSig = _computeSignature(sender, content, topic);
@@ -248,9 +278,10 @@ class PubSubClient implements IPubSub {
     return Uint8List.fromList(utf8.encode('unsubscribe:$topic'));
   }
 
-  /// Encodes a content message for publishing, including security signatures.
+  /// Encodes a content message for publishing, tagged via [_computeSignature].
   ///
-  /// SEC-008: Signs the message with HMAC-SHA256.
+  /// SEC-008: The HMAC-SHA256 tag added here is NOT an authenticity
+  /// signature — see the class-level doc comment for why.
   Uint8List encodePublishRequest(String topic, String message) {
     final String senderStr = Base58().encode(_peerId.value);
     final String signature = _computeSignature(senderStr, message, topic);
@@ -264,7 +295,13 @@ class PubSubClient implements IPubSub {
     return Uint8List.fromList(utf8.encode(jsonEncode(messageWithSender)));
   }
 
-  /// Computes an HMAC-SHA256 signature for message integrity and authenticity.
+  /// Computes an HMAC-SHA256 tag for message integrity — NOT authenticity.
+  ///
+  /// The HMAC key is `sender`, i.e. the public PeerID string, which is also
+  /// transmitted in cleartext in the message this tag accompanies. Since
+  /// the "key" is not secret, this tag can be recomputed by anyone for any
+  /// (sender, topic, content) triple; it only guards against accidental
+  /// corruption, not deliberate forgery. See the class-level doc comment.
   String _computeSignature(String sender, String content, String topic) {
     final List<int> key = utf8.encode(sender);
     final List<int> data = utf8.encode('$topic:$content');

--- a/test/protocols/pubsub/pubsub_client_signature_forgery_test.dart
+++ b/test/protocols/pubsub/pubsub_client_signature_forgery_test.dart
@@ -53,6 +53,10 @@ void main() {
     receiverClient = PubSubClient(mockRouter, receiverPeerId);
   });
 
+  tearDown(() async {
+    if (receiverClient.isStarted) await receiverClient.stop();
+  });
+
   group('SEC-008: PubSub message tag is forgeable (known limitation)', () {
     test(
       'an unrelated attacker can impersonate a connected victim peer '

--- a/test/protocols/pubsub/pubsub_client_signature_forgery_test.dart
+++ b/test/protocols/pubsub/pubsub_client_signature_forgery_test.dart
@@ -1,0 +1,154 @@
+// Regression/documentation test for the PubSub message-tag forgery issue
+// described on PubSubClient's class-level doc comment (SEC-008). Reported
+// to the maintainer via responsible disclosure per SECURITY.md before this
+// branch was opened.
+//
+// Demonstrates that PubSubClient's HMAC "signature" can be forged by any
+// party using only information every message already discloses in
+// cleartext (the sender's own PeerID string), without access to any
+// private key or prior secret from the impersonated peer.
+//
+// This test is expected to start failing once the signing scheme is
+// replaced with real asymmetric (Ed25519) signatures verified against a
+// known public key for `sender` -- that is the fix working as intended,
+// not a regression. See the design notes referenced in the pull request
+// description for the suggested approach.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:dart_ipfs/src/protocols/pubsub/pubsub_client.dart';
+import 'package:dart_ipfs/src/transport/router_events.dart';
+import 'package:dart_ipfs/src/transport/router_interface.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+import 'pubsub_client_coverage_test.mocks.dart';
+
+/// Recomputes PubSubClient's tag exactly as an outside attacker could:
+/// using only the sender PeerID string, topic, and content -- all of which
+/// are public and carried in cleartext by every message. No access to the
+/// victim peer's private key, keystore, or any prior message from them is
+/// required.
+String _publiclyComputableTag(String sender, String topic, String content) {
+  final key = utf8.encode(sender);
+  final data = utf8.encode('$topic:$content');
+  return Hmac(sha256, key).convert(data).toString();
+}
+
+void main() {
+  late PubSubClient receiverClient;
+  late MockRouterInterface mockRouter;
+
+  // The node under test -- could be anyone's node; its own identity is not
+  // what is being impersonated.
+  const receiverPeerId = 'QmReceiver9K7mNpQrStUvWxYzABCDEFGH123';
+  // A third, unrelated peer whose identity gets impersonated below. Its
+  // PeerID is, by design, public (peers must publish it to be dialable).
+  const victimPeerId = 'QmVictim9K7mNpQrStUvWxYzABCDEFGH456';
+
+  setUp(() {
+    mockRouter = MockRouterInterface();
+    receiverClient = PubSubClient(mockRouter, receiverPeerId);
+  });
+
+  group('SEC-008: PubSub message tag is forgeable (known limitation)', () {
+    test(
+      'an unrelated attacker can impersonate a connected victim peer '
+      'without knowing any secret',
+      () async {
+        await receiverClient.start();
+        final capturedHandler =
+            verify(
+                  mockRouter.registerProtocolHandler(any, captureAny),
+                ).captured.single
+                as void Function(NetworkPacket);
+
+        // The victim is a normal, legitimately connected peer elsewhere in
+        // the mesh -- this is the ordinary case, not a special setup.
+        when(mockRouter.isConnectedPeer(victimPeerId)).thenReturn(true);
+
+        const topic = 'general-chat';
+        const forgedContent =
+            'Attacker-controlled message the victim never sent';
+
+        // The "attacker" needs nothing but the victim's public PeerID --
+        // which every peer must publish just to be dialable at all -- to
+        // produce a tag this client treats as valid.
+        final forgedTag = _publiclyComputableTag(
+          victimPeerId,
+          topic,
+          forgedContent,
+        );
+
+        final forgedPacket = NetworkPacket(
+          // The wire-level source need not even be the victim's own
+          // connection: _processIncomingPacket only ever trusts the JSON
+          // `sender` field, never packet.srcPeerId, when deciding who a
+          // message is "from".
+          srcPeerId: 'attacker-own-connection-id',
+          datagram: Uint8List.fromList(
+            utf8.encode(
+              jsonEncode({
+                'sender': victimPeerId,
+                'topic': topic,
+                'content': forgedContent,
+                'signature': forgedTag,
+              }),
+            ),
+          ),
+        );
+
+        final received = receiverClient.messagesStream.first;
+        capturedHandler(forgedPacket);
+
+        final message = await received;
+        expect(message.sender, equals(victimPeerId));
+        expect(message.content, equals(forgedContent));
+      },
+    );
+
+    test(
+      'the tag depends only on public fields, so an independent party '
+      'reproduces the exact same tag without coordinating on a secret',
+      () {
+        const topic = 'topicA';
+        const content = 'hello';
+
+        // What the victim's own, genuine client computes via the public
+        // API when it legitimately publishes -- a fresh instance, standing
+        // in for the real victim's node, distinct from receiverClient.
+        final victimsOwnClient = PubSubClient(
+          MockRouterInterface(),
+          victimPeerId,
+        );
+        final legitimateEncoded = victimsOwnClient.encodePublishRequest(
+          topic,
+          content,
+        );
+        final legitimateTag =
+            (jsonDecode(utf8.decode(legitimateEncoded))
+                    as Map<String, dynamic>)['signature']
+                as String;
+
+        // What an outside party computes, knowing only the same public
+        // fields (sender PeerID, topic, content) -- no secret involved.
+        final forgedTag = _publiclyComputableTag(
+          victimPeerId,
+          topic,
+          content,
+        );
+
+        expect(
+          forgedTag,
+          equals(legitimateTag),
+          reason:
+              'The HMAC key is derived entirely from the public `sender` '
+              'field, so anyone can reproduce the exact same tag without '
+              'ever holding a secret.',
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

`PubSubClient`'s message "signature" (SEC-008) uses HMAC-SHA256 with the sender's own public PeerID string as the key. Since that PeerID is public by design and is re-transmitted in cleartext in the very same message, this tag is reproducible by anyone for any (sender, topic, content) triple -- it does not authenticate who sent a message, contrary to how it's described in the current README.md and SECURITY.md.

This was reported privately first, per SECURITY.md's disclosure process. This PR is the small, low-risk half of that follow-up: it corrects the documentation, explains the gap directly in code, and adds a test that demonstrates the forgery concretely (so it's provable, not just asserted) -- **no runtime behavior changes**.

## What's NOT in this PR (on purpose)

A real fix needs asymmetric signing: sign with the sender's actual Ed25519 identity key (available via `SecurityManager.getSecureKey()`) and verify against that peer's known Ed25519 *public* key. That public key can't be recovered from the PeerID in this codebase -- `PeerId.fromPublicKey` hashes it with SHA-256, which is one-way -- so verification also needs a peer public-key registry populated when peers are first seen (e.g. from the `IdentifyHandler` response, which currently sends this node's own public key but doesn't appear to persist a received peer's public key anywhere lookup-able).

A spec-compliant Ed25519 signer already exists at `lib/src/protocols/pubsub/gossipsub/message_signing.dart` (`Ed25519MessageSigner`) but isn't wired into `PubSubClient` or the default `PubSubHandler` construction path yet. I didn't attempt that wiring here -- it touches connection/identity lifecycle I don't have full context on, and seemed better left to a design you sign off on first. Happy to take a pass at it if useful once you've had a chance to weigh in.

## Changes

- `lib/src/protocols/pubsub/pubsub_client.dart`: corrected doc comments on the class, `_computeSignature`, `encodePublishRequest`, and the verification call site to describe the tag accurately.
- `README.md` / `SECURITY.md`: corrected the "PubSub: HMAC-SHA256 signing" claims.
- `test/protocols/pubsub/pubsub_client_signature_forgery_test.dart` (new): demonstrates that (a) a receiver accepts a forged message claiming to be from an uninvolved third-party peer, and (b) the tag for a given (sender, topic, content) is independently reproducible without any secret.

## Testing

- `dart analyze` -- 0 issues (whole project)
- `dart test test/protocols/pubsub/ test/core/ipfs_node/pubsub_handler_test.dart` -- 85/85 passing, including the 2 new tests
