### PR TITLE
fix(deps): replace image-size with patched fork image-size-next@2.1.1

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/checkout@v7
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4.37.7
+      uses: github/codeql-action/init@v4.37.9
       with:
         languages: 'javascript'
         config: |
@@ -31,10 +31,10 @@ jobs:
             - '.dart_tool/**'
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v4.37.7
+      uses: github/codeql-action/autobuild@v4.37.9
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4.37.7
+      uses: github/codeql-action/analyze@v4.37.9
       with:
         category: "/language:javascript"
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -186,7 +186,7 @@ jobs:
 
       - name: Generate and attach SBOM for runtime image
         if: github.event_name != 'pull_request'
-        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        uses: anchore/sbom-action@v0.24.2
         with:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-runtime.outputs.digest }}
           format: spdx-json

--- a/test/interop/helia/package-lock.json
+++ b/test/interop/helia/package-lock.json
@@ -50,9 +50,9 @@
       }
     },
     "node_modules/@achingbrain/nat-port-mapper/node_modules/@libp2p/interface": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.5.tgz",
-      "integrity": "sha512-RdTchTdakBBc4ShKKsvoME/bJYsrCoVDpdYQVdd4TQ30TCb8QwWKGClqAtw7gfLNuaUKm41xz06kASW6AZpbDA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.3.0.tgz",
+      "integrity": "sha512-SXahM/4IgpiFKTtocbXYSTA1wEUVjktmT1yBCzBbc2Vgsu1VBCg6SvsFmXo2Hbeyev3D8EU+y3uaCKDB43C/Vg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@multiformats/dns": "^1.0.6",
@@ -64,12 +64,12 @@
       }
     },
     "node_modules/@achingbrain/nat-port-mapper/node_modules/@libp2p/logger": {
-      "version": "6.2.10",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-6.2.10.tgz",
-      "integrity": "sha512-recRqNABHG32YXvpMvNepFCuU14d51dF5hs+vR2C/tkqXBQc0Sqg5LtWB2NYPoIJV+JUB50iWLrvBXZUOjLc9Q==",
+      "version": "6.2.13",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-6.2.13.tgz",
+      "integrity": "sha512-+tkZuRPoiFdh+frG//3hQ3goV1uMzRblpZ+mwtezgLXkRNqB5YKBLl+c/rtrurwAUqjCuI/yoEPJBiCizg2z6w==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^3.2.5",
+        "@libp2p/interface": "^3.3.0",
         "@multiformats/multiaddr": "^13.0.3",
         "interface-datastore": "^10.0.1",
         "multiformats": "^14.0.0",
@@ -109,15 +109,15 @@
       }
     },
     "node_modules/@achingbrain/nat-port-mapper/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@achingbrain/nat-port-mapper/node_modules/race-signal": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/race-signal/-/race-signal-2.0.0.tgz",
-      "integrity": "sha512-P31bLhE4ByBX/70QDXMutxnqgwrF1WUXea1O8DXuviAgkdbQ1iQMQotNgzJIBC9yUSn08u/acZrMUhgw7w6GpA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/race-signal/-/race-signal-2.0.2.tgz",
+      "integrity": "sha512-IuNNNY5NLriMFEGl3BVei2xq9NIcpkuAklhPWamhu5tRJrJz0w9sloUMz73YXpmUluE2EZocmJm9rpQqXmCPiA==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@achingbrain/nat-port-mapper/node_modules/uint8-varint": {
@@ -252,14 +252,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
-      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -382,13 +382,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -423,18 +423,18 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
-      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.7",
+        "@babel/generator": "^7.29.8",
         "@babel/helper-globals": "^7.29.7",
-        "@babel/parser": "^7.29.7",
+        "@babel/parser": "^7.29.8",
         "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.7",
+        "@babel/types": "^7.29.8",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -467,9 +467,9 @@
       "peer": true
     },
     "node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -738,12 +738,12 @@
       }
     },
     "node_modules/@helia/delegated-routing-v1-http-api-client/node_modules/@libp2p/crypto": {
-      "version": "5.1.21",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.21.tgz",
-      "integrity": "sha512-GipsBinthJuk7DpwthTUixZHSaKogcxm2glPCP0VkYkEpzZrfEvBEekRvlP5+1Ak8pReaHcz4gPKFA9X6MG0WQ==",
+      "version": "5.1.23",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.23.tgz",
+      "integrity": "sha512-u6XVMD1YpUJgjS5MAayrxlzi+hQcj3FHY0wS6/M/T93ntyCW13BmmRzFb2ESamk65PEuSCAChmQeSzRV2sh2rQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^3.2.5",
+        "@libp2p/interface": "^3.3.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "multiformats": "^14.0.0",
@@ -753,9 +753,9 @@
       }
     },
     "node_modules/@helia/delegated-routing-v1-http-api-client/node_modules/@libp2p/crypto/node_modules/@libp2p/interface": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.5.tgz",
-      "integrity": "sha512-RdTchTdakBBc4ShKKsvoME/bJYsrCoVDpdYQVdd4TQ30TCb8QwWKGClqAtw7gfLNuaUKm41xz06kASW6AZpbDA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.3.0.tgz",
+      "integrity": "sha512-SXahM/4IgpiFKTtocbXYSTA1wEUVjktmT1yBCzBbc2Vgsu1VBCg6SvsFmXo2Hbeyev3D8EU+y3uaCKDB43C/Vg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@multiformats/dns": "^1.0.6",
@@ -779,9 +779,9 @@
       }
     },
     "node_modules/@helia/delegated-routing-v1-http-api-client/node_modules/@libp2p/crypto/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@helia/delegated-routing-v1-http-api-client/node_modules/@libp2p/crypto/node_modules/uint8arraylist": {
@@ -831,12 +831,12 @@
       }
     },
     "node_modules/@helia/delegated-routing-v1-http-api-client/node_modules/@noble/curves": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
-      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.4.0.tgz",
+      "integrity": "sha512-P4/62zrgfH33CneE3Dn4WhJVA22YUU0eR51wKIan4NVRvwsA0YnPTwWGpNbpuacSujmSFLvyzpyuR30+fbq2Ew==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "2.2.0"
+        "@noble/hashes": "2.4.0"
       },
       "engines": {
         "node": ">= 20.19.0"
@@ -846,9 +846,9 @@
       }
     },
     "node_modules/@helia/delegated-routing-v1-http-api-client/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -869,9 +869,9 @@
       }
     },
     "node_modules/@helia/delegated-routing-v1-http-api-client/node_modules/protons-runtime/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@helia/delegated-routing-v1-http-api-client/node_modules/protons-runtime/node_modules/uint8arraylist": {
@@ -903,9 +903,9 @@
       }
     },
     "node_modules/@helia/delegated-routing-v1-http-api-client/node_modules/uint8-varint/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@helia/delegated-routing-v1-http-api-client/node_modules/uint8-varint/node_modules/uint8arraylist": {
@@ -1006,12 +1006,12 @@
       }
     },
     "node_modules/@helia/routers/node_modules/@libp2p/crypto": {
-      "version": "5.1.21",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.21.tgz",
-      "integrity": "sha512-GipsBinthJuk7DpwthTUixZHSaKogcxm2glPCP0VkYkEpzZrfEvBEekRvlP5+1Ak8pReaHcz4gPKFA9X6MG0WQ==",
+      "version": "5.1.23",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.23.tgz",
+      "integrity": "sha512-u6XVMD1YpUJgjS5MAayrxlzi+hQcj3FHY0wS6/M/T93ntyCW13BmmRzFb2ESamk65PEuSCAChmQeSzRV2sh2rQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^3.2.5",
+        "@libp2p/interface": "^3.3.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "multiformats": "^14.0.0",
@@ -1021,9 +1021,9 @@
       }
     },
     "node_modules/@helia/routers/node_modules/@libp2p/crypto/node_modules/@libp2p/interface": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.5.tgz",
-      "integrity": "sha512-RdTchTdakBBc4ShKKsvoME/bJYsrCoVDpdYQVdd4TQ30TCb8QwWKGClqAtw7gfLNuaUKm41xz06kASW6AZpbDA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.3.0.tgz",
+      "integrity": "sha512-SXahM/4IgpiFKTtocbXYSTA1wEUVjktmT1yBCzBbc2Vgsu1VBCg6SvsFmXo2Hbeyev3D8EU+y3uaCKDB43C/Vg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@multiformats/dns": "^1.0.6",
@@ -1047,9 +1047,9 @@
       }
     },
     "node_modules/@helia/routers/node_modules/@libp2p/crypto/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@helia/routers/node_modules/@libp2p/crypto/node_modules/uint8arraylist": {
@@ -1099,12 +1099,12 @@
       }
     },
     "node_modules/@helia/routers/node_modules/@noble/curves": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
-      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.4.0.tgz",
+      "integrity": "sha512-P4/62zrgfH33CneE3Dn4WhJVA22YUU0eR51wKIan4NVRvwsA0YnPTwWGpNbpuacSujmSFLvyzpyuR30+fbq2Ew==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "2.2.0"
+        "@noble/hashes": "2.4.0"
       },
       "engines": {
         "node": ">= 20.19.0"
@@ -1114,9 +1114,9 @@
       }
     },
     "node_modules/@helia/routers/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -1137,9 +1137,9 @@
       }
     },
     "node_modules/@helia/routers/node_modules/protons-runtime/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@helia/routers/node_modules/protons-runtime/node_modules/uint8arraylist": {
@@ -1171,9 +1171,9 @@
       }
     },
     "node_modules/@helia/routers/node_modules/uint8-varint/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@helia/routers/node_modules/uint8-varint/node_modules/uint8arraylist": {
@@ -1275,13 +1275,13 @@
       }
     },
     "node_modules/@ipld/car": {
-      "version": "5.4.6",
-      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-5.4.6.tgz",
-      "integrity": "sha512-f1Iyb9ci8B/TGCyjAuSQ6BOLiy2u8en7rB+SumbyweqXDu3gxYJwYbGzoposKjOzc4CeGlkEbwEw8REoekYAKQ==",
+      "version": "5.4.7",
+      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-5.4.7.tgz",
+      "integrity": "sha512-fohzeOYlm0vM1kGn48zcyDunamXSJaeM5xt0Fmkp5YJkZzgZyjLbb0DcDK6TDgZWo54btkXNACaXUw2H86Elag==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@ipld/dag-cbor": "^10.0.1",
-        "cborg": "^5.0.0",
+        "cborg": "^6.1.1",
         "multiformats": "^14.0.0",
         "varint": "^6.0.0"
       },
@@ -1291,28 +1291,28 @@
       }
     },
     "node_modules/@ipld/car/node_modules/@ipld/dag-cbor": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-10.0.1.tgz",
-      "integrity": "sha512-nF07iiZPqduSXyMxc0jGANArRHFa9hjMQpQlgLOV2O/3xI1CNb5sXhvbmigbMiz5owSGi0Oq10VtauupMojuiw==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-10.0.2.tgz",
+      "integrity": "sha512-1eCD4YMTlkx5i36oQUmeAojLS/wu+XCd1Gs31BA0afk0TaVkhnyMofIAT/pi0wV3HS3/G7QSN/1NibhiksMyZQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "cborg": "^5.0.1",
+        "cborg": "^6.1.1",
         "multiformats": "^14.0.0"
       }
     },
     "node_modules/@ipld/car/node_modules/cborg": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-5.1.7.tgz",
-      "integrity": "sha512-rGg2MG9zZEUKtKqjkBppIWUecTXf9N1vs1Qru43vJWoDaODhCrtmzdehCaA/aq/c1cPI5A0kPrJ5Tf+jIfhV4w==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-6.1.2.tgz",
+      "integrity": "sha512-hQfFh6FuuCDoycN68FtUpjtQx5kCtxOLA8msbpJZxjtxaMqxgHl+4GNwO+0YexH/lHmVzhhAKa0ua+vtmTRoVw==",
       "license": "Apache-2.0",
       "bin": {
         "cborg": "lib/bin.js"
       }
     },
     "node_modules/@ipld/car/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@ipld/dag-cbor": {
@@ -1326,9 +1326,9 @@
       }
     },
     "node_modules/@ipld/dag-cbor/node_modules/cborg": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-5.1.7.tgz",
-      "integrity": "sha512-rGg2MG9zZEUKtKqjkBppIWUecTXf9N1vs1Qru43vJWoDaODhCrtmzdehCaA/aq/c1cPI5A0kPrJ5Tf+jIfhV4w==",
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-5.1.11.tgz",
+      "integrity": "sha512-oc6Pzg/gkTobxHZNgMmny+G99dOeBMbAmnGHcZWMKtolxZBIVwfi0Pj0khxEtNU8HMFdbT5sK0HmtgecDUPP0A==",
       "license": "Apache-2.0",
       "bin": {
         "cborg": "lib/bin.js"
@@ -1345,9 +1345,9 @@
       }
     },
     "node_modules/@ipld/dag-json/node_modules/cborg": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-5.1.7.tgz",
-      "integrity": "sha512-rGg2MG9zZEUKtKqjkBppIWUecTXf9N1vs1Qru43vJWoDaODhCrtmzdehCaA/aq/c1cPI5A0kPrJ5Tf+jIfhV4w==",
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-5.1.11.tgz",
+      "integrity": "sha512-oc6Pzg/gkTobxHZNgMmny+G99dOeBMbAmnGHcZWMKtolxZBIVwfi0Pj0khxEtNU8HMFdbT5sK0HmtgecDUPP0A==",
       "license": "Apache-2.0",
       "bin": {
         "cborg": "lib/bin.js"
@@ -1367,9 +1367,9 @@
       }
     },
     "node_modules/@ipld/dag-pb/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@ipshipyard/libp2p-auto-tls": {
@@ -1397,12 +1397,12 @@
       }
     },
     "node_modules/@ipshipyard/libp2p-auto-tls/node_modules/@libp2p/crypto": {
-      "version": "5.1.21",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.21.tgz",
-      "integrity": "sha512-GipsBinthJuk7DpwthTUixZHSaKogcxm2glPCP0VkYkEpzZrfEvBEekRvlP5+1Ak8pReaHcz4gPKFA9X6MG0WQ==",
+      "version": "5.1.23",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.23.tgz",
+      "integrity": "sha512-u6XVMD1YpUJgjS5MAayrxlzi+hQcj3FHY0wS6/M/T93ntyCW13BmmRzFb2ESamk65PEuSCAChmQeSzRV2sh2rQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^3.2.5",
+        "@libp2p/interface": "^3.3.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "multiformats": "^14.0.0",
@@ -1412,9 +1412,9 @@
       }
     },
     "node_modules/@ipshipyard/libp2p-auto-tls/node_modules/@libp2p/crypto/node_modules/@libp2p/interface": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.5.tgz",
-      "integrity": "sha512-RdTchTdakBBc4ShKKsvoME/bJYsrCoVDpdYQVdd4TQ30TCb8QwWKGClqAtw7gfLNuaUKm41xz06kASW6AZpbDA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.3.0.tgz",
+      "integrity": "sha512-SXahM/4IgpiFKTtocbXYSTA1wEUVjktmT1yBCzBbc2Vgsu1VBCg6SvsFmXo2Hbeyev3D8EU+y3uaCKDB43C/Vg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@multiformats/dns": "^1.0.6",
@@ -1438,9 +1438,9 @@
       }
     },
     "node_modules/@ipshipyard/libp2p-auto-tls/node_modules/@libp2p/crypto/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@ipshipyard/libp2p-auto-tls/node_modules/@libp2p/crypto/node_modules/uint8arraylist": {
@@ -1489,12 +1489,12 @@
       }
     },
     "node_modules/@ipshipyard/libp2p-auto-tls/node_modules/@noble/curves": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
-      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.4.0.tgz",
+      "integrity": "sha512-P4/62zrgfH33CneE3Dn4WhJVA22YUU0eR51wKIan4NVRvwsA0YnPTwWGpNbpuacSujmSFLvyzpyuR30+fbq2Ew==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "2.2.0"
+        "@noble/hashes": "2.4.0"
       },
       "engines": {
         "node": ">= 20.19.0"
@@ -1504,9 +1504,9 @@
       }
     },
     "node_modules/@ipshipyard/libp2p-auto-tls/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -1527,9 +1527,9 @@
       }
     },
     "node_modules/@ipshipyard/libp2p-auto-tls/node_modules/protons-runtime/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@ipshipyard/libp2p-auto-tls/node_modules/protons-runtime/node_modules/uint8arraylist": {
@@ -1561,9 +1561,9 @@
       }
     },
     "node_modules/@ipshipyard/libp2p-auto-tls/node_modules/uint8-varint/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@ipshipyard/libp2p-auto-tls/node_modules/uint8-varint/node_modules/uint8arraylist": {
@@ -1682,9 +1682,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
       "license": "MIT",
       "peer": true
     },
@@ -1726,12 +1726,12 @@
       }
     },
     "node_modules/@libp2p/autonat/node_modules/@libp2p/crypto": {
-      "version": "5.1.21",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.21.tgz",
-      "integrity": "sha512-GipsBinthJuk7DpwthTUixZHSaKogcxm2glPCP0VkYkEpzZrfEvBEekRvlP5+1Ak8pReaHcz4gPKFA9X6MG0WQ==",
+      "version": "5.1.23",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.23.tgz",
+      "integrity": "sha512-u6XVMD1YpUJgjS5MAayrxlzi+hQcj3FHY0wS6/M/T93ntyCW13BmmRzFb2ESamk65PEuSCAChmQeSzRV2sh2rQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^3.2.5",
+        "@libp2p/interface": "^3.3.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "multiformats": "^14.0.0",
@@ -1741,9 +1741,9 @@
       }
     },
     "node_modules/@libp2p/autonat/node_modules/@libp2p/crypto/node_modules/@libp2p/interface": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.5.tgz",
-      "integrity": "sha512-RdTchTdakBBc4ShKKsvoME/bJYsrCoVDpdYQVdd4TQ30TCb8QwWKGClqAtw7gfLNuaUKm41xz06kASW6AZpbDA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.3.0.tgz",
+      "integrity": "sha512-SXahM/4IgpiFKTtocbXYSTA1wEUVjktmT1yBCzBbc2Vgsu1VBCg6SvsFmXo2Hbeyev3D8EU+y3uaCKDB43C/Vg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@multiformats/dns": "^1.0.6",
@@ -1767,9 +1767,9 @@
       }
     },
     "node_modules/@libp2p/autonat/node_modules/@libp2p/crypto/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/autonat/node_modules/@libp2p/crypto/node_modules/protons-runtime": {
@@ -1830,12 +1830,12 @@
       }
     },
     "node_modules/@libp2p/autonat/node_modules/@noble/curves": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
-      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.4.0.tgz",
+      "integrity": "sha512-P4/62zrgfH33CneE3Dn4WhJVA22YUU0eR51wKIan4NVRvwsA0YnPTwWGpNbpuacSujmSFLvyzpyuR30+fbq2Ew==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "2.2.0"
+        "@noble/hashes": "2.4.0"
       },
       "engines": {
         "node": ">= 20.19.0"
@@ -1845,9 +1845,9 @@
       }
     },
     "node_modules/@libp2p/autonat/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -1867,9 +1867,9 @@
       }
     },
     "node_modules/@libp2p/autonat/node_modules/uint8-varint/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/autonat/node_modules/uint8-varint/node_modules/uint8arraylist": {
@@ -1905,12 +1905,12 @@
       }
     },
     "node_modules/@libp2p/bootstrap/node_modules/@libp2p/crypto": {
-      "version": "5.1.21",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.21.tgz",
-      "integrity": "sha512-GipsBinthJuk7DpwthTUixZHSaKogcxm2glPCP0VkYkEpzZrfEvBEekRvlP5+1Ak8pReaHcz4gPKFA9X6MG0WQ==",
+      "version": "5.1.23",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.23.tgz",
+      "integrity": "sha512-u6XVMD1YpUJgjS5MAayrxlzi+hQcj3FHY0wS6/M/T93ntyCW13BmmRzFb2ESamk65PEuSCAChmQeSzRV2sh2rQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^3.2.5",
+        "@libp2p/interface": "^3.3.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "multiformats": "^14.0.0",
@@ -1920,9 +1920,9 @@
       }
     },
     "node_modules/@libp2p/bootstrap/node_modules/@libp2p/crypto/node_modules/@libp2p/interface": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.5.tgz",
-      "integrity": "sha512-RdTchTdakBBc4ShKKsvoME/bJYsrCoVDpdYQVdd4TQ30TCb8QwWKGClqAtw7gfLNuaUKm41xz06kASW6AZpbDA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.3.0.tgz",
+      "integrity": "sha512-SXahM/4IgpiFKTtocbXYSTA1wEUVjktmT1yBCzBbc2Vgsu1VBCg6SvsFmXo2Hbeyev3D8EU+y3uaCKDB43C/Vg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@multiformats/dns": "^1.0.6",
@@ -1946,9 +1946,9 @@
       }
     },
     "node_modules/@libp2p/bootstrap/node_modules/@libp2p/crypto/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/bootstrap/node_modules/@libp2p/crypto/node_modules/uint8arraylist": {
@@ -1998,12 +1998,12 @@
       }
     },
     "node_modules/@libp2p/bootstrap/node_modules/@noble/curves": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
-      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.4.0.tgz",
+      "integrity": "sha512-P4/62zrgfH33CneE3Dn4WhJVA22YUU0eR51wKIan4NVRvwsA0YnPTwWGpNbpuacSujmSFLvyzpyuR30+fbq2Ew==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "2.2.0"
+        "@noble/hashes": "2.4.0"
       },
       "engines": {
         "node": ">= 20.19.0"
@@ -2013,9 +2013,9 @@
       }
     },
     "node_modules/@libp2p/bootstrap/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -2036,9 +2036,9 @@
       }
     },
     "node_modules/@libp2p/bootstrap/node_modules/protons-runtime/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/bootstrap/node_modules/protons-runtime/node_modules/uint8arraylist": {
@@ -2070,9 +2070,9 @@
       }
     },
     "node_modules/@libp2p/bootstrap/node_modules/uint8-varint/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/bootstrap/node_modules/uint8-varint/node_modules/uint8arraylist": {
@@ -2122,12 +2122,12 @@
       }
     },
     "node_modules/@libp2p/circuit-relay-v2/node_modules/@libp2p/crypto": {
-      "version": "5.1.21",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.21.tgz",
-      "integrity": "sha512-GipsBinthJuk7DpwthTUixZHSaKogcxm2glPCP0VkYkEpzZrfEvBEekRvlP5+1Ak8pReaHcz4gPKFA9X6MG0WQ==",
+      "version": "5.1.23",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.23.tgz",
+      "integrity": "sha512-u6XVMD1YpUJgjS5MAayrxlzi+hQcj3FHY0wS6/M/T93ntyCW13BmmRzFb2ESamk65PEuSCAChmQeSzRV2sh2rQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^3.2.5",
+        "@libp2p/interface": "^3.3.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "multiformats": "^14.0.0",
@@ -2137,9 +2137,9 @@
       }
     },
     "node_modules/@libp2p/circuit-relay-v2/node_modules/@libp2p/crypto/node_modules/@libp2p/interface": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.5.tgz",
-      "integrity": "sha512-RdTchTdakBBc4ShKKsvoME/bJYsrCoVDpdYQVdd4TQ30TCb8QwWKGClqAtw7gfLNuaUKm41xz06kASW6AZpbDA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.3.0.tgz",
+      "integrity": "sha512-SXahM/4IgpiFKTtocbXYSTA1wEUVjktmT1yBCzBbc2Vgsu1VBCg6SvsFmXo2Hbeyev3D8EU+y3uaCKDB43C/Vg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@multiformats/dns": "^1.0.6",
@@ -2163,9 +2163,9 @@
       }
     },
     "node_modules/@libp2p/circuit-relay-v2/node_modules/@libp2p/crypto/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/circuit-relay-v2/node_modules/@libp2p/crypto/node_modules/protons-runtime": {
@@ -2226,12 +2226,12 @@
       }
     },
     "node_modules/@libp2p/circuit-relay-v2/node_modules/@noble/curves": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
-      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.4.0.tgz",
+      "integrity": "sha512-P4/62zrgfH33CneE3Dn4WhJVA22YUU0eR51wKIan4NVRvwsA0YnPTwWGpNbpuacSujmSFLvyzpyuR30+fbq2Ew==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "2.2.0"
+        "@noble/hashes": "2.4.0"
       },
       "engines": {
         "node": ">= 20.19.0"
@@ -2241,9 +2241,9 @@
       }
     },
     "node_modules/@libp2p/circuit-relay-v2/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -2263,9 +2263,9 @@
       }
     },
     "node_modules/@libp2p/circuit-relay-v2/node_modules/uint8-varint/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/circuit-relay-v2/node_modules/uint8-varint/node_modules/uint8arraylist": {
@@ -2287,25 +2287,25 @@
       }
     },
     "node_modules/@libp2p/config": {
-      "version": "1.1.34",
-      "resolved": "https://registry.npmjs.org/@libp2p/config/-/config-1.1.34.tgz",
-      "integrity": "sha512-av0PNvJBTTwHxC1wFsjyvPuwHsE7mZOm0sQ7n0wKC5ONW/HfgGrpSiffjuPnDixJd3A/MkVNq5ycaQeM44Nb6Q==",
+      "version": "1.1.37",
+      "resolved": "https://registry.npmjs.org/@libp2p/config/-/config-1.1.37.tgz",
+      "integrity": "sha512-aapBnhItf4Zi1BV2k8iuUan4nIiPM9QwHu8r44DC/MlBvah/Wf7Gv37w0h6vQucwMi9dieg2EXbZHxEwfWA5ag==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.21",
-        "@libp2p/interface": "^3.2.5",
-        "@libp2p/keychain": "^6.1.4",
-        "@libp2p/logger": "^6.2.10",
+        "@libp2p/crypto": "^5.1.23",
+        "@libp2p/interface": "^3.3.0",
+        "@libp2p/keychain": "^6.1.7",
+        "@libp2p/logger": "^6.2.13",
         "interface-datastore": "^10.0.1"
       }
     },
     "node_modules/@libp2p/config/node_modules/@libp2p/crypto": {
-      "version": "5.1.21",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.21.tgz",
-      "integrity": "sha512-GipsBinthJuk7DpwthTUixZHSaKogcxm2glPCP0VkYkEpzZrfEvBEekRvlP5+1Ak8pReaHcz4gPKFA9X6MG0WQ==",
+      "version": "5.1.23",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.23.tgz",
+      "integrity": "sha512-u6XVMD1YpUJgjS5MAayrxlzi+hQcj3FHY0wS6/M/T93ntyCW13BmmRzFb2ESamk65PEuSCAChmQeSzRV2sh2rQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^3.2.5",
+        "@libp2p/interface": "^3.3.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "multiformats": "^14.0.0",
@@ -2315,9 +2315,9 @@
       }
     },
     "node_modules/@libp2p/config/node_modules/@libp2p/interface": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.5.tgz",
-      "integrity": "sha512-RdTchTdakBBc4ShKKsvoME/bJYsrCoVDpdYQVdd4TQ30TCb8QwWKGClqAtw7gfLNuaUKm41xz06kASW6AZpbDA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.3.0.tgz",
+      "integrity": "sha512-SXahM/4IgpiFKTtocbXYSTA1wEUVjktmT1yBCzBbc2Vgsu1VBCg6SvsFmXo2Hbeyev3D8EU+y3uaCKDB43C/Vg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@multiformats/dns": "^1.0.6",
@@ -2329,13 +2329,13 @@
       }
     },
     "node_modules/@libp2p/config/node_modules/@libp2p/keychain": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/keychain/-/keychain-6.1.4.tgz",
-      "integrity": "sha512-vExk59BOOoOafgPpnARFxacFvtiotOzJ/UZKdmZLGP9e0J1rJPm+Aqbek7aP4oA7JX0q2OjLK/skJSzbwUk9sQ==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/@libp2p/keychain/-/keychain-6.1.7.tgz",
+      "integrity": "sha512-kemRM/37UXfkqmZsFFIsICX8iMX3TUShYGaRL7xXqNq3oIebm12e54DW1dtDuUnpNLctdF6zWPPelUHQm50Szg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.21",
-        "@libp2p/interface": "^3.2.5",
+        "@libp2p/crypto": "^5.1.23",
+        "@libp2p/interface": "^3.3.0",
         "@noble/hashes": "^2.0.1",
         "asn1js": "^3.0.6",
         "interface-datastore": "^10.0.1",
@@ -2345,12 +2345,12 @@
       }
     },
     "node_modules/@libp2p/config/node_modules/@libp2p/logger": {
-      "version": "6.2.10",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-6.2.10.tgz",
-      "integrity": "sha512-recRqNABHG32YXvpMvNepFCuU14d51dF5hs+vR2C/tkqXBQc0Sqg5LtWB2NYPoIJV+JUB50iWLrvBXZUOjLc9Q==",
+      "version": "6.2.13",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-6.2.13.tgz",
+      "integrity": "sha512-+tkZuRPoiFdh+frG//3hQ3goV1uMzRblpZ+mwtezgLXkRNqB5YKBLl+c/rtrurwAUqjCuI/yoEPJBiCizg2z6w==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^3.2.5",
+        "@libp2p/interface": "^3.3.0",
         "@multiformats/multiaddr": "^13.0.3",
         "interface-datastore": "^10.0.1",
         "multiformats": "^14.0.0",
@@ -2370,12 +2370,12 @@
       }
     },
     "node_modules/@libp2p/config/node_modules/@noble/curves": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
-      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.4.0.tgz",
+      "integrity": "sha512-P4/62zrgfH33CneE3Dn4WhJVA22YUU0eR51wKIan4NVRvwsA0YnPTwWGpNbpuacSujmSFLvyzpyuR30+fbq2Ew==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "2.2.0"
+        "@noble/hashes": "2.4.0"
       },
       "engines": {
         "node": ">= 20.19.0"
@@ -2385,9 +2385,9 @@
       }
     },
     "node_modules/@libp2p/config/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -2417,9 +2417,9 @@
       }
     },
     "node_modules/@libp2p/config/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/config/node_modules/protons-runtime": {
@@ -2533,12 +2533,12 @@
       }
     },
     "node_modules/@libp2p/http-fetch/node_modules/@libp2p/crypto": {
-      "version": "5.1.21",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.21.tgz",
-      "integrity": "sha512-GipsBinthJuk7DpwthTUixZHSaKogcxm2glPCP0VkYkEpzZrfEvBEekRvlP5+1Ak8pReaHcz4gPKFA9X6MG0WQ==",
+      "version": "5.1.23",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.23.tgz",
+      "integrity": "sha512-u6XVMD1YpUJgjS5MAayrxlzi+hQcj3FHY0wS6/M/T93ntyCW13BmmRzFb2ESamk65PEuSCAChmQeSzRV2sh2rQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^3.2.5",
+        "@libp2p/interface": "^3.3.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "multiformats": "^14.0.0",
@@ -2548,9 +2548,9 @@
       }
     },
     "node_modules/@libp2p/http-fetch/node_modules/@libp2p/crypto/node_modules/@libp2p/interface": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.5.tgz",
-      "integrity": "sha512-RdTchTdakBBc4ShKKsvoME/bJYsrCoVDpdYQVdd4TQ30TCb8QwWKGClqAtw7gfLNuaUKm41xz06kASW6AZpbDA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.3.0.tgz",
+      "integrity": "sha512-SXahM/4IgpiFKTtocbXYSTA1wEUVjktmT1yBCzBbc2Vgsu1VBCg6SvsFmXo2Hbeyev3D8EU+y3uaCKDB43C/Vg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@multiformats/dns": "^1.0.6",
@@ -2574,9 +2574,9 @@
       }
     },
     "node_modules/@libp2p/http-fetch/node_modules/@libp2p/crypto/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/http-fetch/node_modules/@libp2p/crypto/node_modules/uint8-varint": {
@@ -2636,12 +2636,12 @@
       }
     },
     "node_modules/@libp2p/http-fetch/node_modules/@noble/curves": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
-      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.4.0.tgz",
+      "integrity": "sha512-P4/62zrgfH33CneE3Dn4WhJVA22YUU0eR51wKIan4NVRvwsA0YnPTwWGpNbpuacSujmSFLvyzpyuR30+fbq2Ew==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "2.2.0"
+        "@noble/hashes": "2.4.0"
       },
       "engines": {
         "node": ">= 20.19.0"
@@ -2651,9 +2651,9 @@
       }
     },
     "node_modules/@libp2p/http-fetch/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -2674,9 +2674,9 @@
       }
     },
     "node_modules/@libp2p/http-fetch/node_modules/protons-runtime/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/http-fetch/node_modules/protons-runtime/node_modules/uint8-varint": {
@@ -2731,12 +2731,12 @@
       }
     },
     "node_modules/@libp2p/identify/node_modules/@libp2p/crypto": {
-      "version": "5.1.21",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.21.tgz",
-      "integrity": "sha512-GipsBinthJuk7DpwthTUixZHSaKogcxm2glPCP0VkYkEpzZrfEvBEekRvlP5+1Ak8pReaHcz4gPKFA9X6MG0WQ==",
+      "version": "5.1.23",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.23.tgz",
+      "integrity": "sha512-u6XVMD1YpUJgjS5MAayrxlzi+hQcj3FHY0wS6/M/T93ntyCW13BmmRzFb2ESamk65PEuSCAChmQeSzRV2sh2rQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^3.2.5",
+        "@libp2p/interface": "^3.3.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "multiformats": "^14.0.0",
@@ -2746,9 +2746,9 @@
       }
     },
     "node_modules/@libp2p/identify/node_modules/@libp2p/crypto/node_modules/@libp2p/interface": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.5.tgz",
-      "integrity": "sha512-RdTchTdakBBc4ShKKsvoME/bJYsrCoVDpdYQVdd4TQ30TCb8QwWKGClqAtw7gfLNuaUKm41xz06kASW6AZpbDA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.3.0.tgz",
+      "integrity": "sha512-SXahM/4IgpiFKTtocbXYSTA1wEUVjktmT1yBCzBbc2Vgsu1VBCg6SvsFmXo2Hbeyev3D8EU+y3uaCKDB43C/Vg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@multiformats/dns": "^1.0.6",
@@ -2772,9 +2772,9 @@
       }
     },
     "node_modules/@libp2p/identify/node_modules/@libp2p/crypto/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/identify/node_modules/@libp2p/crypto/node_modules/protons-runtime": {
@@ -2835,12 +2835,12 @@
       }
     },
     "node_modules/@libp2p/identify/node_modules/@noble/curves": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
-      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.4.0.tgz",
+      "integrity": "sha512-P4/62zrgfH33CneE3Dn4WhJVA22YUU0eR51wKIan4NVRvwsA0YnPTwWGpNbpuacSujmSFLvyzpyuR30+fbq2Ew==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "2.2.0"
+        "@noble/hashes": "2.4.0"
       },
       "engines": {
         "node": ">= 20.19.0"
@@ -2850,9 +2850,9 @@
       }
     },
     "node_modules/@libp2p/identify/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -2872,9 +2872,9 @@
       }
     },
     "node_modules/@libp2p/identify/node_modules/uint8-varint/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/identify/node_modules/uint8-varint/node_modules/uint8arraylist": {
@@ -2938,19 +2938,19 @@
       }
     },
     "node_modules/@libp2p/kad-dht": {
-      "version": "16.3.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/kad-dht/-/kad-dht-16.3.4.tgz",
-      "integrity": "sha512-/deVcwDnqkqzWI6uX2ki3EpLI5V68GuMIVYITjn2mbLIpwNnxYKYmPkqPMW2AQ0LUTdMczSv6ebSYwMWxVCeQQ==",
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/kad-dht/-/kad-dht-16.4.5.tgz",
+      "integrity": "sha512-Pxmk3pIfe5Ih1xr+CY1uzw8AXRY+2VI6p3iebM4ljueu+dovEPIahW8tq4F2iNHIQftuc9Svncw4JikwrU7I1w==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.21",
-        "@libp2p/interface": "^3.2.5",
-        "@libp2p/interface-internal": "^3.1.8",
-        "@libp2p/peer-collections": "^7.0.23",
-        "@libp2p/peer-id": "^6.0.12",
-        "@libp2p/ping": "^3.1.8",
+        "@libp2p/crypto": "^5.1.23",
+        "@libp2p/interface": "^3.3.0",
+        "@libp2p/interface-internal": "^3.1.13",
+        "@libp2p/peer-collections": "^7.0.28",
+        "@libp2p/peer-id": "^6.0.15",
+        "@libp2p/ping": "^3.1.13",
         "@libp2p/record": "^4.0.15",
-        "@libp2p/utils": "^7.2.4",
+        "@libp2p/utils": "^7.4.1",
         "@multiformats/multiaddr": "^13.0.3",
         "@multiformats/multiaddr-matcher": "^3.0.2",
         "any-signal": "^4.1.1",
@@ -2977,12 +2977,12 @@
       }
     },
     "node_modules/@libp2p/kad-dht/node_modules/@libp2p/crypto": {
-      "version": "5.1.21",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.21.tgz",
-      "integrity": "sha512-GipsBinthJuk7DpwthTUixZHSaKogcxm2glPCP0VkYkEpzZrfEvBEekRvlP5+1Ak8pReaHcz4gPKFA9X6MG0WQ==",
+      "version": "5.1.23",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.23.tgz",
+      "integrity": "sha512-u6XVMD1YpUJgjS5MAayrxlzi+hQcj3FHY0wS6/M/T93ntyCW13BmmRzFb2ESamk65PEuSCAChmQeSzRV2sh2rQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^3.2.5",
+        "@libp2p/interface": "^3.3.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "multiformats": "^14.0.0",
@@ -2992,9 +2992,9 @@
       }
     },
     "node_modules/@libp2p/kad-dht/node_modules/@libp2p/interface": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.5.tgz",
-      "integrity": "sha512-RdTchTdakBBc4ShKKsvoME/bJYsrCoVDpdYQVdd4TQ30TCb8QwWKGClqAtw7gfLNuaUKm41xz06kASW6AZpbDA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.3.0.tgz",
+      "integrity": "sha512-SXahM/4IgpiFKTtocbXYSTA1wEUVjktmT1yBCzBbc2Vgsu1VBCg6SvsFmXo2Hbeyev3D8EU+y3uaCKDB43C/Vg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@multiformats/dns": "^1.0.6",
@@ -3006,24 +3006,24 @@
       }
     },
     "node_modules/@libp2p/kad-dht/node_modules/@libp2p/interface-internal": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-internal/-/interface-internal-3.1.8.tgz",
-      "integrity": "sha512-MJ/DR+H8xdhRIdDSh/BzHIxgmBQ9HoVoBwISOb582IDd5ZXF6xrtaVzC6Vn4n/OMwUDPfda3OD/aMNAlygtoEw==",
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-internal/-/interface-internal-3.1.13.tgz",
+      "integrity": "sha512-+vjQzpQl+0uoWCyNwV5NDnv1RAK9LDeWGeMbx/Fl2ZWrndtuFUPa9LxwqHXrTly6YOhgUatSzVqZBWnrQ1PxGg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^3.2.5",
-        "@libp2p/peer-collections": "^7.0.23",
+        "@libp2p/interface": "^3.3.0",
+        "@libp2p/peer-collections": "^7.0.28",
         "@multiformats/multiaddr": "^13.0.3",
         "progress-events": "^1.0.1"
       }
     },
     "node_modules/@libp2p/kad-dht/node_modules/@libp2p/logger": {
-      "version": "6.2.10",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-6.2.10.tgz",
-      "integrity": "sha512-recRqNABHG32YXvpMvNepFCuU14d51dF5hs+vR2C/tkqXBQc0Sqg5LtWB2NYPoIJV+JUB50iWLrvBXZUOjLc9Q==",
+      "version": "6.2.13",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-6.2.13.tgz",
+      "integrity": "sha512-+tkZuRPoiFdh+frG//3hQ3goV1uMzRblpZ+mwtezgLXkRNqB5YKBLl+c/rtrurwAUqjCuI/yoEPJBiCizg2z6w==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^3.2.5",
+        "@libp2p/interface": "^3.3.0",
         "@multiformats/multiaddr": "^13.0.3",
         "interface-datastore": "^10.0.1",
         "multiformats": "^14.0.0",
@@ -3031,37 +3031,37 @@
       }
     },
     "node_modules/@libp2p/kad-dht/node_modules/@libp2p/peer-collections": {
-      "version": "7.0.23",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-7.0.23.tgz",
-      "integrity": "sha512-m7KX5Z4l+kd9JRGthFJyxuO9/1JfrVg+5H83oQcn1C0juboroijCVe6GoX1kWdKKyVDWtliDjvK7ZyA/+LilPQ==",
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-7.0.28.tgz",
+      "integrity": "sha512-+evafZ5oSnGRfB7z+ycf09ehzNhCKoOZaiHgi6TpnDitpRQM5KQeN0H9Ep2uNJtzyW944HOG41BqcSaHbEHv7Q==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^3.2.5",
-        "@libp2p/peer-id": "^6.0.12",
-        "@libp2p/utils": "^7.2.4",
+        "@libp2p/interface": "^3.3.0",
+        "@libp2p/peer-id": "^6.0.15",
+        "@libp2p/utils": "^7.4.1",
         "multiformats": "^14.0.0"
       }
     },
     "node_modules/@libp2p/kad-dht/node_modules/@libp2p/peer-id": {
-      "version": "6.0.12",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.12.tgz",
-      "integrity": "sha512-U44MeKs+U1SqZPqS0RDzjjcS9ERix2zJsJkTcqi8I+5flEz4uVAObBDxvkkaTaqRFRXCXEPjL5kA4UbgVubCZQ==",
+      "version": "6.0.15",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.15.tgz",
+      "integrity": "sha512-aIbYJcldMNOIzmm9J57aESjZInYFdrQ9AY0ij+qn0Oam2vBxDfEIJZxJu+JzVkB2rVvT+FHDQXKWT2nAqNgB8w==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.21",
-        "@libp2p/interface": "^3.2.5",
+        "@libp2p/crypto": "^5.1.23",
+        "@libp2p/interface": "^3.3.0",
         "multiformats": "^14.0.0",
         "uint8arrays": "^6.1.1"
       }
     },
     "node_modules/@libp2p/kad-dht/node_modules/@libp2p/ping": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@libp2p/ping/-/ping-3.1.8.tgz",
-      "integrity": "sha512-jcqIAyULOP5e0zSo9XQkeUAfoVgzmcJGDoSKYyDKoZDGvw35h+IR7Kkn/lU1h4imS7HlZkcPvgPOl3p1gGppWw==",
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/@libp2p/ping/-/ping-3.1.13.tgz",
+      "integrity": "sha512-zB0TYbxWD73z3kqHrC2PDk7CAX0wQ0smz6mZ9okE4MoFgJv+XtMaIB2pB/4eT7xjWwdc2w3mYRmq+lMyXl3nXQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^3.2.5",
-        "@libp2p/interface-internal": "^3.1.8",
+        "@libp2p/interface": "^3.3.0",
+        "@libp2p/interface-internal": "^3.1.13",
         "p-event": "^7.0.0",
         "race-signal": "^2.0.0",
         "uint8arraylist": "^3.0.2",
@@ -3069,20 +3069,20 @@
       }
     },
     "node_modules/@libp2p/kad-dht/node_modules/@libp2p/utils": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-7.2.4.tgz",
-      "integrity": "sha512-rp5mlFJqV1cc+Kfuxt61RXbWaHaku/HmfhiEHIvFaaP3do1QUSlG+Tjbufwb5r7JzotYnmL4egNDTlNnpjZsBA==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-7.4.1.tgz",
+      "integrity": "sha512-e9cZeop+awI0rFczG4DvAwVeHqBhuCZfTyskvgONfKQrsT7L0BSlTlTTzZoFF8Dnb+QrzHsoIpnl0PrCr0h+Hg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@chainsafe/is-ip": "^2.1.0",
         "@chainsafe/netmask": "^2.0.0",
-        "@libp2p/interface": "^3.2.5",
-        "@libp2p/logger": "^6.2.10",
+        "@libp2p/interface": "^3.3.0",
+        "@libp2p/logger": "^6.2.13",
         "@multiformats/multiaddr": "^13.0.3",
         "@multiformats/multiaddr-matcher": "^3.0.2",
         "@sindresorhus/fnv1a": "^3.1.0",
         "any-signal": "^4.1.1",
-        "cborg": "^5.1.0",
+        "cborg": "^6.0.0",
         "delay": "^7.0.0",
         "is-loopback-addr": "^2.0.2",
         "it-length-prefixed": "^11.0.1",
@@ -3094,6 +3094,7 @@
         "p-defer": "^4.0.1",
         "p-event": "^7.0.0",
         "progress-events": "^1.1.0",
+        "protons-runtime": "^7.0.0",
         "race-signal": "^2.0.0",
         "uint8-varint": "^3.0.0",
         "uint8arraylist": "^3.0.2",
@@ -3122,12 +3123,12 @@
       }
     },
     "node_modules/@libp2p/kad-dht/node_modules/@noble/curves": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
-      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.4.0.tgz",
+      "integrity": "sha512-P4/62zrgfH33CneE3Dn4WhJVA22YUU0eR51wKIan4NVRvwsA0YnPTwWGpNbpuacSujmSFLvyzpyuR30+fbq2Ew==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "2.2.0"
+        "@noble/hashes": "2.4.0"
       },
       "engines": {
         "node": ">= 20.19.0"
@@ -3137,9 +3138,9 @@
       }
     },
     "node_modules/@libp2p/kad-dht/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -3149,9 +3150,9 @@
       }
     },
     "node_modules/@libp2p/kad-dht/node_modules/cborg": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-5.1.7.tgz",
-      "integrity": "sha512-rGg2MG9zZEUKtKqjkBppIWUecTXf9N1vs1Qru43vJWoDaODhCrtmzdehCaA/aq/c1cPI5A0kPrJ5Tf+jIfhV4w==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-6.1.2.tgz",
+      "integrity": "sha512-hQfFh6FuuCDoycN68FtUpjtQx5kCtxOLA8msbpJZxjtxaMqxgHl+4GNwO+0YexH/lHmVzhhAKa0ua+vtmTRoVw==",
       "license": "Apache-2.0",
       "bin": {
         "cborg": "lib/bin.js"
@@ -3217,37 +3218,10 @@
       }
     },
     "node_modules/@libp2p/kad-dht/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
-    },
-    "node_modules/@libp2p/kad-dht/node_modules/p-event": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/p-event/-/p-event-7.1.0.tgz",
-      "integrity": "sha512-/lkPs5W1aC3cp6vqZefpdosOn65J571sWodyfOQiF0+tmDCpU+H8Atwpu0vQROCVUlZuToDN5eyTLsMLLc54mg==",
-      "license": "MIT",
-      "dependencies": {
-        "p-timeout": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@libp2p/kad-dht/node_modules/p-timeout": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
-      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/@libp2p/kad-dht/node_modules/protons-runtime": {
       "version": "7.0.0",
@@ -3261,9 +3235,9 @@
       }
     },
     "node_modules/@libp2p/kad-dht/node_modules/race-signal": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/race-signal/-/race-signal-2.0.0.tgz",
-      "integrity": "sha512-P31bLhE4ByBX/70QDXMutxnqgwrF1WUXea1O8DXuviAgkdbQ1iQMQotNgzJIBC9yUSn08u/acZrMUhgw7w6GpA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/race-signal/-/race-signal-2.0.2.tgz",
+      "integrity": "sha512-IuNNNY5NLriMFEGl3BVei2xq9NIcpkuAklhPWamhu5tRJrJz0w9sloUMz73YXpmUluE2EZocmJm9rpQqXmCPiA==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/kad-dht/node_modules/uint8-varint": {
@@ -3312,12 +3286,12 @@
       }
     },
     "node_modules/@libp2p/keychain/node_modules/@libp2p/crypto": {
-      "version": "5.1.21",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.21.tgz",
-      "integrity": "sha512-GipsBinthJuk7DpwthTUixZHSaKogcxm2glPCP0VkYkEpzZrfEvBEekRvlP5+1Ak8pReaHcz4gPKFA9X6MG0WQ==",
+      "version": "5.1.23",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.23.tgz",
+      "integrity": "sha512-u6XVMD1YpUJgjS5MAayrxlzi+hQcj3FHY0wS6/M/T93ntyCW13BmmRzFb2ESamk65PEuSCAChmQeSzRV2sh2rQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^3.2.5",
+        "@libp2p/interface": "^3.3.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "multiformats": "^14.0.0",
@@ -3327,9 +3301,9 @@
       }
     },
     "node_modules/@libp2p/keychain/node_modules/@libp2p/crypto/node_modules/@libp2p/interface": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.5.tgz",
-      "integrity": "sha512-RdTchTdakBBc4ShKKsvoME/bJYsrCoVDpdYQVdd4TQ30TCb8QwWKGClqAtw7gfLNuaUKm41xz06kASW6AZpbDA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.3.0.tgz",
+      "integrity": "sha512-SXahM/4IgpiFKTtocbXYSTA1wEUVjktmT1yBCzBbc2Vgsu1VBCg6SvsFmXo2Hbeyev3D8EU+y3uaCKDB43C/Vg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@multiformats/dns": "^1.0.6",
@@ -3353,9 +3327,9 @@
       }
     },
     "node_modules/@libp2p/keychain/node_modules/@libp2p/crypto/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -3365,9 +3339,9 @@
       }
     },
     "node_modules/@libp2p/keychain/node_modules/@libp2p/crypto/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/keychain/node_modules/@libp2p/crypto/node_modules/uint8arraylist": {
@@ -3405,12 +3379,12 @@
       }
     },
     "node_modules/@libp2p/keychain/node_modules/@noble/curves": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
-      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.4.0.tgz",
+      "integrity": "sha512-P4/62zrgfH33CneE3Dn4WhJVA22YUU0eR51wKIan4NVRvwsA0YnPTwWGpNbpuacSujmSFLvyzpyuR30+fbq2Ew==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "2.2.0"
+        "@noble/hashes": "2.4.0"
       },
       "engines": {
         "node": ">= 20.19.0"
@@ -3420,9 +3394,9 @@
       }
     },
     "node_modules/@libp2p/keychain/node_modules/@noble/curves/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -3443,9 +3417,9 @@
       }
     },
     "node_modules/@libp2p/keychain/node_modules/protons-runtime/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/keychain/node_modules/protons-runtime/node_modules/uint8arraylist": {
@@ -3477,9 +3451,9 @@
       }
     },
     "node_modules/@libp2p/keychain/node_modules/uint8-varint/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/keychain/node_modules/uint8-varint/node_modules/uint8arraylist": {
@@ -3547,12 +3521,12 @@
       }
     },
     "node_modules/@libp2p/mdns/node_modules/@libp2p/crypto": {
-      "version": "5.1.21",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.21.tgz",
-      "integrity": "sha512-GipsBinthJuk7DpwthTUixZHSaKogcxm2glPCP0VkYkEpzZrfEvBEekRvlP5+1Ak8pReaHcz4gPKFA9X6MG0WQ==",
+      "version": "5.1.23",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.23.tgz",
+      "integrity": "sha512-u6XVMD1YpUJgjS5MAayrxlzi+hQcj3FHY0wS6/M/T93ntyCW13BmmRzFb2ESamk65PEuSCAChmQeSzRV2sh2rQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^3.2.5",
+        "@libp2p/interface": "^3.3.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "multiformats": "^14.0.0",
@@ -3562,9 +3536,9 @@
       }
     },
     "node_modules/@libp2p/mdns/node_modules/@libp2p/crypto/node_modules/@libp2p/interface": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.5.tgz",
-      "integrity": "sha512-RdTchTdakBBc4ShKKsvoME/bJYsrCoVDpdYQVdd4TQ30TCb8QwWKGClqAtw7gfLNuaUKm41xz06kASW6AZpbDA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.3.0.tgz",
+      "integrity": "sha512-SXahM/4IgpiFKTtocbXYSTA1wEUVjktmT1yBCzBbc2Vgsu1VBCg6SvsFmXo2Hbeyev3D8EU+y3uaCKDB43C/Vg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@multiformats/dns": "^1.0.6",
@@ -3588,9 +3562,9 @@
       }
     },
     "node_modules/@libp2p/mdns/node_modules/@libp2p/crypto/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/mdns/node_modules/@libp2p/crypto/node_modules/uint8arraylist": {
@@ -3640,12 +3614,12 @@
       }
     },
     "node_modules/@libp2p/mdns/node_modules/@noble/curves": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
-      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.4.0.tgz",
+      "integrity": "sha512-P4/62zrgfH33CneE3Dn4WhJVA22YUU0eR51wKIan4NVRvwsA0YnPTwWGpNbpuacSujmSFLvyzpyuR30+fbq2Ew==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "2.2.0"
+        "@noble/hashes": "2.4.0"
       },
       "engines": {
         "node": ">= 20.19.0"
@@ -3655,9 +3629,9 @@
       }
     },
     "node_modules/@libp2p/mdns/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -3678,9 +3652,9 @@
       }
     },
     "node_modules/@libp2p/mdns/node_modules/protons-runtime/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/mdns/node_modules/protons-runtime/node_modules/uint8arraylist": {
@@ -3712,9 +3686,9 @@
       }
     },
     "node_modules/@libp2p/mdns/node_modules/uint8-varint/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/mdns/node_modules/uint8-varint/node_modules/uint8arraylist": {
@@ -3877,12 +3851,12 @@
       }
     },
     "node_modules/@libp2p/peer-collections/node_modules/@libp2p/crypto": {
-      "version": "5.1.21",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.21.tgz",
-      "integrity": "sha512-GipsBinthJuk7DpwthTUixZHSaKogcxm2glPCP0VkYkEpzZrfEvBEekRvlP5+1Ak8pReaHcz4gPKFA9X6MG0WQ==",
+      "version": "5.1.23",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.23.tgz",
+      "integrity": "sha512-u6XVMD1YpUJgjS5MAayrxlzi+hQcj3FHY0wS6/M/T93ntyCW13BmmRzFb2ESamk65PEuSCAChmQeSzRV2sh2rQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^3.2.5",
+        "@libp2p/interface": "^3.3.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "multiformats": "^14.0.0",
@@ -3892,9 +3866,9 @@
       }
     },
     "node_modules/@libp2p/peer-collections/node_modules/@libp2p/crypto/node_modules/@libp2p/interface": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.5.tgz",
-      "integrity": "sha512-RdTchTdakBBc4ShKKsvoME/bJYsrCoVDpdYQVdd4TQ30TCb8QwWKGClqAtw7gfLNuaUKm41xz06kASW6AZpbDA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.3.0.tgz",
+      "integrity": "sha512-SXahM/4IgpiFKTtocbXYSTA1wEUVjktmT1yBCzBbc2Vgsu1VBCg6SvsFmXo2Hbeyev3D8EU+y3uaCKDB43C/Vg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@multiformats/dns": "^1.0.6",
@@ -3918,9 +3892,9 @@
       }
     },
     "node_modules/@libp2p/peer-collections/node_modules/@libp2p/crypto/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/peer-collections/node_modules/@libp2p/crypto/node_modules/uint8arraylist": {
@@ -3970,12 +3944,12 @@
       }
     },
     "node_modules/@libp2p/peer-collections/node_modules/@noble/curves": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
-      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.4.0.tgz",
+      "integrity": "sha512-P4/62zrgfH33CneE3Dn4WhJVA22YUU0eR51wKIan4NVRvwsA0YnPTwWGpNbpuacSujmSFLvyzpyuR30+fbq2Ew==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "2.2.0"
+        "@noble/hashes": "2.4.0"
       },
       "engines": {
         "node": ">= 20.19.0"
@@ -3985,9 +3959,9 @@
       }
     },
     "node_modules/@libp2p/peer-collections/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -4008,9 +3982,9 @@
       }
     },
     "node_modules/@libp2p/peer-collections/node_modules/protons-runtime/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/peer-collections/node_modules/protons-runtime/node_modules/uint8arraylist": {
@@ -4042,9 +4016,9 @@
       }
     },
     "node_modules/@libp2p/peer-collections/node_modules/uint8-varint/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/peer-collections/node_modules/uint8-varint/node_modules/uint8arraylist": {
@@ -4095,12 +4069,12 @@
       }
     },
     "node_modules/@libp2p/peer-record/node_modules/@libp2p/crypto": {
-      "version": "5.1.21",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.21.tgz",
-      "integrity": "sha512-GipsBinthJuk7DpwthTUixZHSaKogcxm2glPCP0VkYkEpzZrfEvBEekRvlP5+1Ak8pReaHcz4gPKFA9X6MG0WQ==",
+      "version": "5.1.23",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.23.tgz",
+      "integrity": "sha512-u6XVMD1YpUJgjS5MAayrxlzi+hQcj3FHY0wS6/M/T93ntyCW13BmmRzFb2ESamk65PEuSCAChmQeSzRV2sh2rQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^3.2.5",
+        "@libp2p/interface": "^3.3.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "multiformats": "^14.0.0",
@@ -4110,9 +4084,9 @@
       }
     },
     "node_modules/@libp2p/peer-record/node_modules/@libp2p/crypto/node_modules/@libp2p/interface": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.5.tgz",
-      "integrity": "sha512-RdTchTdakBBc4ShKKsvoME/bJYsrCoVDpdYQVdd4TQ30TCb8QwWKGClqAtw7gfLNuaUKm41xz06kASW6AZpbDA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.3.0.tgz",
+      "integrity": "sha512-SXahM/4IgpiFKTtocbXYSTA1wEUVjktmT1yBCzBbc2Vgsu1VBCg6SvsFmXo2Hbeyev3D8EU+y3uaCKDB43C/Vg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@multiformats/dns": "^1.0.6",
@@ -4136,9 +4110,9 @@
       }
     },
     "node_modules/@libp2p/peer-record/node_modules/@libp2p/crypto/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/peer-record/node_modules/@libp2p/crypto/node_modules/protons-runtime": {
@@ -4209,12 +4183,12 @@
       }
     },
     "node_modules/@libp2p/peer-record/node_modules/@noble/curves": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
-      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.4.0.tgz",
+      "integrity": "sha512-P4/62zrgfH33CneE3Dn4WhJVA22YUU0eR51wKIan4NVRvwsA0YnPTwWGpNbpuacSujmSFLvyzpyuR30+fbq2Ew==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "2.2.0"
+        "@noble/hashes": "2.4.0"
       },
       "engines": {
         "node": ">= 20.19.0"
@@ -4224,9 +4198,9 @@
       }
     },
     "node_modules/@libp2p/peer-record/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -4258,12 +4232,12 @@
       }
     },
     "node_modules/@libp2p/peer-store/node_modules/@libp2p/crypto": {
-      "version": "5.1.21",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.21.tgz",
-      "integrity": "sha512-GipsBinthJuk7DpwthTUixZHSaKogcxm2glPCP0VkYkEpzZrfEvBEekRvlP5+1Ak8pReaHcz4gPKFA9X6MG0WQ==",
+      "version": "5.1.23",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.23.tgz",
+      "integrity": "sha512-u6XVMD1YpUJgjS5MAayrxlzi+hQcj3FHY0wS6/M/T93ntyCW13BmmRzFb2ESamk65PEuSCAChmQeSzRV2sh2rQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^3.2.5",
+        "@libp2p/interface": "^3.3.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "multiformats": "^14.0.0",
@@ -4273,9 +4247,9 @@
       }
     },
     "node_modules/@libp2p/peer-store/node_modules/@libp2p/crypto/node_modules/@libp2p/interface": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.5.tgz",
-      "integrity": "sha512-RdTchTdakBBc4ShKKsvoME/bJYsrCoVDpdYQVdd4TQ30TCb8QwWKGClqAtw7gfLNuaUKm41xz06kASW6AZpbDA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.3.0.tgz",
+      "integrity": "sha512-SXahM/4IgpiFKTtocbXYSTA1wEUVjktmT1yBCzBbc2Vgsu1VBCg6SvsFmXo2Hbeyev3D8EU+y3uaCKDB43C/Vg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@multiformats/dns": "^1.0.6",
@@ -4299,9 +4273,9 @@
       }
     },
     "node_modules/@libp2p/peer-store/node_modules/@libp2p/crypto/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/peer-store/node_modules/@libp2p/crypto/node_modules/protons-runtime": {
@@ -4362,12 +4336,12 @@
       }
     },
     "node_modules/@libp2p/peer-store/node_modules/@noble/curves": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
-      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.4.0.tgz",
+      "integrity": "sha512-P4/62zrgfH33CneE3Dn4WhJVA22YUU0eR51wKIan4NVRvwsA0YnPTwWGpNbpuacSujmSFLvyzpyuR30+fbq2Ew==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "2.2.0"
+        "@noble/hashes": "2.4.0"
       },
       "engines": {
         "node": ">= 20.19.0"
@@ -4377,9 +4351,9 @@
       }
     },
     "node_modules/@libp2p/peer-store/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -4399,9 +4373,9 @@
       }
     },
     "node_modules/@libp2p/peer-store/node_modules/uint8-varint/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/peer-store/node_modules/uint8-varint/node_modules/uint8arraylist": {
@@ -4438,12 +4412,12 @@
       }
     },
     "node_modules/@libp2p/ping/node_modules/@libp2p/crypto": {
-      "version": "5.1.21",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.21.tgz",
-      "integrity": "sha512-GipsBinthJuk7DpwthTUixZHSaKogcxm2glPCP0VkYkEpzZrfEvBEekRvlP5+1Ak8pReaHcz4gPKFA9X6MG0WQ==",
+      "version": "5.1.23",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.23.tgz",
+      "integrity": "sha512-u6XVMD1YpUJgjS5MAayrxlzi+hQcj3FHY0wS6/M/T93ntyCW13BmmRzFb2ESamk65PEuSCAChmQeSzRV2sh2rQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^3.2.5",
+        "@libp2p/interface": "^3.3.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "multiformats": "^14.0.0",
@@ -4453,9 +4427,9 @@
       }
     },
     "node_modules/@libp2p/ping/node_modules/@libp2p/crypto/node_modules/@libp2p/interface": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.5.tgz",
-      "integrity": "sha512-RdTchTdakBBc4ShKKsvoME/bJYsrCoVDpdYQVdd4TQ30TCb8QwWKGClqAtw7gfLNuaUKm41xz06kASW6AZpbDA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.3.0.tgz",
+      "integrity": "sha512-SXahM/4IgpiFKTtocbXYSTA1wEUVjktmT1yBCzBbc2Vgsu1VBCg6SvsFmXo2Hbeyev3D8EU+y3uaCKDB43C/Vg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@multiformats/dns": "^1.0.6",
@@ -4479,9 +4453,9 @@
       }
     },
     "node_modules/@libp2p/ping/node_modules/@libp2p/crypto/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/ping/node_modules/@libp2p/crypto/node_modules/uint8arraylist": {
@@ -4519,12 +4493,12 @@
       }
     },
     "node_modules/@libp2p/ping/node_modules/@noble/curves": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
-      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.4.0.tgz",
+      "integrity": "sha512-P4/62zrgfH33CneE3Dn4WhJVA22YUU0eR51wKIan4NVRvwsA0YnPTwWGpNbpuacSujmSFLvyzpyuR30+fbq2Ew==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "2.2.0"
+        "@noble/hashes": "2.4.0"
       },
       "engines": {
         "node": ">= 20.19.0"
@@ -4534,9 +4508,9 @@
       }
     },
     "node_modules/@libp2p/ping/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -4557,9 +4531,9 @@
       }
     },
     "node_modules/@libp2p/ping/node_modules/protons-runtime/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/ping/node_modules/protons-runtime/node_modules/uint8arraylist": {
@@ -4591,9 +4565,9 @@
       }
     },
     "node_modules/@libp2p/ping/node_modules/uint8-varint/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/ping/node_modules/uint8-varint/node_modules/uint8arraylist": {
@@ -4633,12 +4607,12 @@
       }
     },
     "node_modules/@libp2p/pnet/node_modules/@libp2p/crypto": {
-      "version": "5.1.21",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.21.tgz",
-      "integrity": "sha512-GipsBinthJuk7DpwthTUixZHSaKogcxm2glPCP0VkYkEpzZrfEvBEekRvlP5+1Ak8pReaHcz4gPKFA9X6MG0WQ==",
+      "version": "5.1.23",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.23.tgz",
+      "integrity": "sha512-u6XVMD1YpUJgjS5MAayrxlzi+hQcj3FHY0wS6/M/T93ntyCW13BmmRzFb2ESamk65PEuSCAChmQeSzRV2sh2rQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^3.2.5",
+        "@libp2p/interface": "^3.3.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "multiformats": "^14.0.0",
@@ -4648,9 +4622,9 @@
       }
     },
     "node_modules/@libp2p/pnet/node_modules/@libp2p/crypto/node_modules/@libp2p/interface": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.5.tgz",
-      "integrity": "sha512-RdTchTdakBBc4ShKKsvoME/bJYsrCoVDpdYQVdd4TQ30TCb8QwWKGClqAtw7gfLNuaUKm41xz06kASW6AZpbDA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.3.0.tgz",
+      "integrity": "sha512-SXahM/4IgpiFKTtocbXYSTA1wEUVjktmT1yBCzBbc2Vgsu1VBCg6SvsFmXo2Hbeyev3D8EU+y3uaCKDB43C/Vg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@multiformats/dns": "^1.0.6",
@@ -4674,9 +4648,9 @@
       }
     },
     "node_modules/@libp2p/pnet/node_modules/@libp2p/crypto/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/pnet/node_modules/@libp2p/crypto/node_modules/uint8arraylist": {
@@ -4714,12 +4688,12 @@
       }
     },
     "node_modules/@libp2p/pnet/node_modules/@noble/curves": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
-      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.4.0.tgz",
+      "integrity": "sha512-P4/62zrgfH33CneE3Dn4WhJVA22YUU0eR51wKIan4NVRvwsA0YnPTwWGpNbpuacSujmSFLvyzpyuR30+fbq2Ew==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "2.2.0"
+        "@noble/hashes": "2.4.0"
       },
       "engines": {
         "node": ">= 20.19.0"
@@ -4729,9 +4703,9 @@
       }
     },
     "node_modules/@libp2p/pnet/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -4752,9 +4726,9 @@
       }
     },
     "node_modules/@libp2p/pnet/node_modules/protons-runtime/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/pnet/node_modules/protons-runtime/node_modules/uint8arraylist": {
@@ -4786,9 +4760,9 @@
       }
     },
     "node_modules/@libp2p/pnet/node_modules/uint8-varint/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/pnet/node_modules/uint8-varint/node_modules/uint8arraylist": {
@@ -4821,9 +4795,9 @@
       }
     },
     "node_modules/@libp2p/record/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/record/node_modules/protons-runtime": {
@@ -4955,12 +4929,12 @@
       }
     },
     "node_modules/@libp2p/tls/node_modules/@libp2p/crypto": {
-      "version": "5.1.21",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.21.tgz",
-      "integrity": "sha512-GipsBinthJuk7DpwthTUixZHSaKogcxm2glPCP0VkYkEpzZrfEvBEekRvlP5+1Ak8pReaHcz4gPKFA9X6MG0WQ==",
+      "version": "5.1.23",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.23.tgz",
+      "integrity": "sha512-u6XVMD1YpUJgjS5MAayrxlzi+hQcj3FHY0wS6/M/T93ntyCW13BmmRzFb2ESamk65PEuSCAChmQeSzRV2sh2rQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^3.2.5",
+        "@libp2p/interface": "^3.3.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "multiformats": "^14.0.0",
@@ -4970,9 +4944,9 @@
       }
     },
     "node_modules/@libp2p/tls/node_modules/@libp2p/crypto/node_modules/@libp2p/interface": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.5.tgz",
-      "integrity": "sha512-RdTchTdakBBc4ShKKsvoME/bJYsrCoVDpdYQVdd4TQ30TCb8QwWKGClqAtw7gfLNuaUKm41xz06kASW6AZpbDA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.3.0.tgz",
+      "integrity": "sha512-SXahM/4IgpiFKTtocbXYSTA1wEUVjktmT1yBCzBbc2Vgsu1VBCg6SvsFmXo2Hbeyev3D8EU+y3uaCKDB43C/Vg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@multiformats/dns": "^1.0.6",
@@ -4996,9 +4970,9 @@
       }
     },
     "node_modules/@libp2p/tls/node_modules/@libp2p/crypto/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/tls/node_modules/@libp2p/crypto/node_modules/protons-runtime": {
@@ -5059,12 +5033,12 @@
       }
     },
     "node_modules/@libp2p/tls/node_modules/@noble/curves": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
-      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.4.0.tgz",
+      "integrity": "sha512-P4/62zrgfH33CneE3Dn4WhJVA22YUU0eR51wKIan4NVRvwsA0YnPTwWGpNbpuacSujmSFLvyzpyuR30+fbq2Ew==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "2.2.0"
+        "@noble/hashes": "2.4.0"
       },
       "engines": {
         "node": ">= 20.19.0"
@@ -5074,9 +5048,9 @@
       }
     },
     "node_modules/@libp2p/tls/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -5096,9 +5070,9 @@
       }
     },
     "node_modules/@libp2p/tls/node_modules/uint8-varint/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/tls/node_modules/uint8-varint/node_modules/uint8arraylist": {
@@ -5185,12 +5159,12 @@
       }
     },
     "node_modules/@libp2p/utils/node_modules/@libp2p/crypto": {
-      "version": "5.1.21",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.21.tgz",
-      "integrity": "sha512-GipsBinthJuk7DpwthTUixZHSaKogcxm2glPCP0VkYkEpzZrfEvBEekRvlP5+1Ak8pReaHcz4gPKFA9X6MG0WQ==",
+      "version": "5.1.23",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.23.tgz",
+      "integrity": "sha512-u6XVMD1YpUJgjS5MAayrxlzi+hQcj3FHY0wS6/M/T93ntyCW13BmmRzFb2ESamk65PEuSCAChmQeSzRV2sh2rQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^3.2.5",
+        "@libp2p/interface": "^3.3.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "multiformats": "^14.0.0",
@@ -5200,9 +5174,9 @@
       }
     },
     "node_modules/@libp2p/utils/node_modules/@libp2p/crypto/node_modules/@libp2p/interface": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.5.tgz",
-      "integrity": "sha512-RdTchTdakBBc4ShKKsvoME/bJYsrCoVDpdYQVdd4TQ30TCb8QwWKGClqAtw7gfLNuaUKm41xz06kASW6AZpbDA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.3.0.tgz",
+      "integrity": "sha512-SXahM/4IgpiFKTtocbXYSTA1wEUVjktmT1yBCzBbc2Vgsu1VBCg6SvsFmXo2Hbeyev3D8EU+y3uaCKDB43C/Vg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@multiformats/dns": "^1.0.6",
@@ -5226,9 +5200,9 @@
       }
     },
     "node_modules/@libp2p/utils/node_modules/@libp2p/crypto/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/utils/node_modules/@libp2p/crypto/node_modules/uint8arraylist": {
@@ -5266,12 +5240,12 @@
       }
     },
     "node_modules/@libp2p/utils/node_modules/@noble/curves": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
-      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.4.0.tgz",
+      "integrity": "sha512-P4/62zrgfH33CneE3Dn4WhJVA22YUU0eR51wKIan4NVRvwsA0YnPTwWGpNbpuacSujmSFLvyzpyuR30+fbq2Ew==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "2.2.0"
+        "@noble/hashes": "2.4.0"
       },
       "engines": {
         "node": ">= 20.19.0"
@@ -5281,9 +5255,9 @@
       }
     },
     "node_modules/@libp2p/utils/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -5304,9 +5278,9 @@
       }
     },
     "node_modules/@libp2p/utils/node_modules/protons-runtime/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/utils/node_modules/protons-runtime/node_modules/uint8arraylist": {
@@ -5338,9 +5312,9 @@
       }
     },
     "node_modules/@libp2p/utils/node_modules/uint8-varint/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/utils/node_modules/uint8-varint/node_modules/uint8arraylist": {
@@ -5404,9 +5378,9 @@
       }
     },
     "node_modules/@libp2p/webrtc/node_modules/@chainsafe/as-sha256": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@chainsafe/as-sha256/-/as-sha256-1.2.4.tgz",
-      "integrity": "sha512-3GXDysZOKD6cTYbm48lEdXdUbS7cafjXQZfgHOspTByhoGR/JM3KBXyF3vE6bf63ImjNPyoEZwnQcpYPQ6k3bQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@chainsafe/as-sha256/-/as-sha256-1.2.5.tgz",
+      "integrity": "sha512-8LzmWxBC/2O5BgbP+aRom/FaDJMrM04VZMlVIivYTc6yNQKYrONmIv27m3q/1VBgxrfrNNqmibitb2hE2tQzIw==",
       "license": "Apache-2.0"
     },
     "node_modules/@libp2p/webrtc/node_modules/@chainsafe/libp2p-noise": {
@@ -5435,12 +5409,12 @@
       }
     },
     "node_modules/@libp2p/webrtc/node_modules/@libp2p/crypto": {
-      "version": "5.1.21",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.21.tgz",
-      "integrity": "sha512-GipsBinthJuk7DpwthTUixZHSaKogcxm2glPCP0VkYkEpzZrfEvBEekRvlP5+1Ak8pReaHcz4gPKFA9X6MG0WQ==",
+      "version": "5.1.23",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.23.tgz",
+      "integrity": "sha512-u6XVMD1YpUJgjS5MAayrxlzi+hQcj3FHY0wS6/M/T93ntyCW13BmmRzFb2ESamk65PEuSCAChmQeSzRV2sh2rQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^3.2.5",
+        "@libp2p/interface": "^3.3.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "multiformats": "^14.0.0",
@@ -5450,9 +5424,9 @@
       }
     },
     "node_modules/@libp2p/webrtc/node_modules/@libp2p/crypto/node_modules/@libp2p/interface": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.5.tgz",
-      "integrity": "sha512-RdTchTdakBBc4ShKKsvoME/bJYsrCoVDpdYQVdd4TQ30TCb8QwWKGClqAtw7gfLNuaUKm41xz06kASW6AZpbDA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.3.0.tgz",
+      "integrity": "sha512-SXahM/4IgpiFKTtocbXYSTA1wEUVjktmT1yBCzBbc2Vgsu1VBCg6SvsFmXo2Hbeyev3D8EU+y3uaCKDB43C/Vg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@multiformats/dns": "^1.0.6",
@@ -5476,12 +5450,12 @@
       }
     },
     "node_modules/@libp2p/webrtc/node_modules/@libp2p/crypto/node_modules/@noble/curves": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
-      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.4.0.tgz",
+      "integrity": "sha512-P4/62zrgfH33CneE3Dn4WhJVA22YUU0eR51wKIan4NVRvwsA0YnPTwWGpNbpuacSujmSFLvyzpyuR30+fbq2Ew==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "2.2.0"
+        "@noble/hashes": "2.4.0"
       },
       "engines": {
         "node": ">= 20.19.0"
@@ -5491,9 +5465,9 @@
       }
     },
     "node_modules/@libp2p/webrtc/node_modules/@libp2p/crypto/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -5503,9 +5477,9 @@
       }
     },
     "node_modules/@libp2p/webrtc/node_modules/@libp2p/crypto/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/webrtc/node_modules/@libp2p/crypto/node_modules/protons-runtime": {
@@ -5650,6 +5624,21 @@
         "uint8arraylist": "^2.4.8"
       }
     },
+    "node_modules/@libp2p/websockets/node_modules/p-event": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-6.0.1.tgz",
+      "integrity": "sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-timeout": "^6.1.2"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@libp2p/yamux": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/@libp2p/yamux/-/yamux-8.0.1.tgz",
@@ -5663,9 +5652,9 @@
       }
     },
     "node_modules/@libp2p/yamux/node_modules/@libp2p/interface": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.5.tgz",
-      "integrity": "sha512-RdTchTdakBBc4ShKKsvoME/bJYsrCoVDpdYQVdd4TQ30TCb8QwWKGClqAtw7gfLNuaUKm41xz06kASW6AZpbDA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.3.0.tgz",
+      "integrity": "sha512-SXahM/4IgpiFKTtocbXYSTA1wEUVjktmT1yBCzBbc2Vgsu1VBCg6SvsFmXo2Hbeyev3D8EU+y3uaCKDB43C/Vg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@multiformats/dns": "^1.0.6",
@@ -5686,12 +5675,12 @@
       }
     },
     "node_modules/@libp2p/yamux/node_modules/@libp2p/logger": {
-      "version": "6.2.10",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-6.2.10.tgz",
-      "integrity": "sha512-recRqNABHG32YXvpMvNepFCuU14d51dF5hs+vR2C/tkqXBQc0Sqg5LtWB2NYPoIJV+JUB50iWLrvBXZUOjLc9Q==",
+      "version": "6.2.13",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-6.2.13.tgz",
+      "integrity": "sha512-+tkZuRPoiFdh+frG//3hQ3goV1uMzRblpZ+mwtezgLXkRNqB5YKBLl+c/rtrurwAUqjCuI/yoEPJBiCizg2z6w==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^3.2.5",
+        "@libp2p/interface": "^3.3.0",
         "@multiformats/multiaddr": "^13.0.3",
         "interface-datastore": "^10.0.1",
         "multiformats": "^14.0.0",
@@ -5699,20 +5688,20 @@
       }
     },
     "node_modules/@libp2p/yamux/node_modules/@libp2p/utils": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-7.2.4.tgz",
-      "integrity": "sha512-rp5mlFJqV1cc+Kfuxt61RXbWaHaku/HmfhiEHIvFaaP3do1QUSlG+Tjbufwb5r7JzotYnmL4egNDTlNnpjZsBA==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-7.4.1.tgz",
+      "integrity": "sha512-e9cZeop+awI0rFczG4DvAwVeHqBhuCZfTyskvgONfKQrsT7L0BSlTlTTzZoFF8Dnb+QrzHsoIpnl0PrCr0h+Hg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@chainsafe/is-ip": "^2.1.0",
         "@chainsafe/netmask": "^2.0.0",
-        "@libp2p/interface": "^3.2.5",
-        "@libp2p/logger": "^6.2.10",
+        "@libp2p/interface": "^3.3.0",
+        "@libp2p/logger": "^6.2.13",
         "@multiformats/multiaddr": "^13.0.3",
         "@multiformats/multiaddr-matcher": "^3.0.2",
         "@sindresorhus/fnv1a": "^3.1.0",
         "any-signal": "^4.1.1",
-        "cborg": "^5.1.0",
+        "cborg": "^6.0.0",
         "delay": "^7.0.0",
         "is-loopback-addr": "^2.0.2",
         "it-length-prefixed": "^11.0.1",
@@ -5724,6 +5713,7 @@
         "p-defer": "^4.0.1",
         "p-event": "^7.0.0",
         "progress-events": "^1.1.0",
+        "protons-runtime": "^7.0.0",
         "race-signal": "^2.0.0",
         "uint8-varint": "^3.0.0",
         "uint8arraylist": "^3.0.2",
@@ -5761,9 +5751,9 @@
       }
     },
     "node_modules/@libp2p/yamux/node_modules/cborg": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-5.1.7.tgz",
-      "integrity": "sha512-rGg2MG9zZEUKtKqjkBppIWUecTXf9N1vs1Qru43vJWoDaODhCrtmzdehCaA/aq/c1cPI5A0kPrJ5Tf+jIfhV4w==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-6.1.2.tgz",
+      "integrity": "sha512-hQfFh6FuuCDoycN68FtUpjtQx5kCtxOLA8msbpJZxjtxaMqxgHl+4GNwO+0YexH/lHmVzhhAKa0ua+vtmTRoVw==",
       "license": "Apache-2.0",
       "bin": {
         "cborg": "lib/bin.js"
@@ -5847,42 +5837,35 @@
       }
     },
     "node_modules/@libp2p/yamux/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
-    "node_modules/@libp2p/yamux/node_modules/p-event": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/p-event/-/p-event-7.1.0.tgz",
-      "integrity": "sha512-/lkPs5W1aC3cp6vqZefpdosOn65J571sWodyfOQiF0+tmDCpU+H8Atwpu0vQROCVUlZuToDN5eyTLsMLLc54mg==",
-      "license": "MIT",
+    "node_modules/@libp2p/yamux/node_modules/protons-runtime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-7.0.0.tgz",
+      "integrity": "sha512-r/e72006xoVND4Uvf1aIs4OQOkJaASBU3ip4DzOWAktoKAkTiOYqKoS3TYMBm8HnnYU8+h0uEzr5gIRwk/pmTg==",
+      "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "p-timeout": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "uint8-varint": "^3.0.0",
+        "uint8arraylist": "^3.0.0",
+        "uint8arrays": "^6.0.0"
       }
     },
-    "node_modules/@libp2p/yamux/node_modules/p-timeout": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
-      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+    "node_modules/@libp2p/yamux/node_modules/protons-runtime/node_modules/uint8arraylist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-3.0.2.tgz",
+      "integrity": "sha512-LDVoq9BQaGJzGDUovEnoX6rpKCvnY/Jbtws4ikwnBzjRbq5qBAFpBZevUEbSmMM87aO0Sp+wOZy2ZXf5yODmXQ==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "uint8arrays": "^6.0.0"
       }
     },
     "node_modules/@libp2p/yamux/node_modules/race-signal": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/race-signal/-/race-signal-2.0.0.tgz",
-      "integrity": "sha512-P31bLhE4ByBX/70QDXMutxnqgwrF1WUXea1O8DXuviAgkdbQ1iQMQotNgzJIBC9yUSn08u/acZrMUhgw7w6GpA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/race-signal/-/race-signal-2.0.2.tgz",
+      "integrity": "sha512-IuNNNY5NLriMFEGl3BVei2xq9NIcpkuAklhPWamhu5tRJrJz0w9sloUMz73YXpmUluE2EZocmJm9rpQqXmCPiA==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/yamux/node_modules/uint8-varint": {
@@ -5928,9 +5911,9 @@
       }
     },
     "node_modules/@multiformats/dns/node_modules/@libp2p/interface": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.5.tgz",
-      "integrity": "sha512-RdTchTdakBBc4ShKKsvoME/bJYsrCoVDpdYQVdd4TQ30TCb8QwWKGClqAtw7gfLNuaUKm41xz06kASW6AZpbDA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.3.0.tgz",
+      "integrity": "sha512-SXahM/4IgpiFKTtocbXYSTA1wEUVjktmT1yBCzBbc2Vgsu1VBCg6SvsFmXo2Hbeyev3D8EU+y3uaCKDB43C/Vg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@multiformats/dns": "^1.0.6",
@@ -5954,15 +5937,15 @@
       }
     },
     "node_modules/@multiformats/dns/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@multiformats/dns/node_modules/p-queue": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.1.tgz",
-      "integrity": "sha512-POWdiIPmsUPGwb4FeQ4OBg46aqmcInSWe45CKDsGHiOBiVQM9chqfQTuqhuTzcg2Vz9faTI65at0KkVyVEiCHw==",
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.3.tgz",
+      "integrity": "sha512-NXAOdnEe5FsZJfT4oK84lE1Y5cFFdWlRuOo5tww8DyNMxyRXwn39fIkUtNLKppcPC+UYU/bXujNCUGDv01y7CA==",
       "license": "MIT",
       "dependencies": {
         "eventemitter3": "^5.0.4",
@@ -6104,129 +6087,159 @@
       }
     },
     "node_modules/@peculiar/asn1-cms": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.8.0.tgz",
-      "integrity": "sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA==",
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.9.4.tgz",
+      "integrity": "sha512-cben7oxmQsUGZqotus7yt0srYdncOT6RNWcTQ77T2RFOXejYVYkXadrfePdRcrVpO9K95IRLKKglG2k38jKXuw==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.8.0",
-        "@peculiar/asn1-x509": "^2.8.0",
-        "@peculiar/asn1-x509-attr": "^2.8.0",
+        "@peculiar/asn1-schema": "^2.9.4",
+        "@peculiar/asn1-x509": "^2.9.4",
+        "@peculiar/asn1-x509-attr": "^2.9.4",
         "asn1js": "^3.0.10",
         "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@peculiar/asn1-csr": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.8.0.tgz",
-      "integrity": "sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg==",
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.9.4.tgz",
+      "integrity": "sha512-xd4YN4vpRjkDAQWVfZZkeu12IEND7DOpkqaHSIHxZl1uggUNa9Ju0QxY2jHvDAS9pP0zhRBytg8ifsnGo3V0jw==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.8.0",
-        "@peculiar/asn1-x509": "^2.8.0",
+        "@peculiar/asn1-schema": "^2.9.4",
+        "@peculiar/asn1-x509": "^2.9.4",
         "asn1js": "^3.0.10",
         "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@peculiar/asn1-ecc": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.8.0.tgz",
-      "integrity": "sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==",
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.9.4.tgz",
+      "integrity": "sha512-JJXefFshRAuVAjWQo/39bkg1ywc1VaiO44S8RRC+Ykvf/u2KDmYffoDb0ZBPCR5uJy4AGKQhl8mX+Q8ShcWaXQ==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.8.0",
-        "@peculiar/asn1-x509": "^2.8.0",
+        "@peculiar/asn1-schema": "^2.9.4",
+        "@peculiar/asn1-x509": "^2.9.4",
         "asn1js": "^3.0.10",
         "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@peculiar/asn1-pfx": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.8.0.tgz",
-      "integrity": "sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg==",
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.9.4.tgz",
+      "integrity": "sha512-khuGzHTzNzk4GDlIBEILyIs6Lce0yn0ZBdoI9v93kmNncfZRhD+AQ5ODFqdhvoE8cMJF/JMTQ8yA+t1D14kqCw==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-cms": "^2.8.0",
-        "@peculiar/asn1-pkcs8": "^2.8.0",
-        "@peculiar/asn1-rsa": "^2.8.0",
-        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-cms": "^2.9.4",
+        "@peculiar/asn1-pkcs8": "^2.9.4",
+        "@peculiar/asn1-rsa": "^2.9.4",
+        "@peculiar/asn1-schema": "^2.9.4",
         "asn1js": "^3.0.10",
         "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@peculiar/asn1-pkcs8": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.8.0.tgz",
-      "integrity": "sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA==",
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.9.4.tgz",
+      "integrity": "sha512-duRdotlUx9eDZe6QrQpQKl61RbWykCHBCkKayP8V8XdEFwlKHZ8qGGDMyS6Pye7OX7nLFttTTpRkJeet78ckwQ==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.8.0",
-        "@peculiar/asn1-x509": "^2.8.0",
+        "@peculiar/asn1-schema": "^2.9.4",
+        "@peculiar/asn1-x509": "^2.9.4",
         "asn1js": "^3.0.10",
         "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@peculiar/asn1-pkcs9": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.8.0.tgz",
-      "integrity": "sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ==",
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.9.4.tgz",
+      "integrity": "sha512-kaL4cNxBpdQE2dKlyZBqz4ygCrwffO+8wfoxTEqM1Z8RadvCeELBRzcv0dzM8aY9azHMwODO5nxU65zXmhToOQ==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-cms": "^2.8.0",
-        "@peculiar/asn1-pfx": "^2.8.0",
-        "@peculiar/asn1-pkcs8": "^2.8.0",
-        "@peculiar/asn1-schema": "^2.8.0",
-        "@peculiar/asn1-x509": "^2.8.0",
-        "@peculiar/asn1-x509-attr": "^2.8.0",
+        "@peculiar/asn1-cms": "^2.9.4",
+        "@peculiar/asn1-pfx": "^2.9.4",
+        "@peculiar/asn1-pkcs8": "^2.9.4",
+        "@peculiar/asn1-schema": "^2.9.4",
+        "@peculiar/asn1-x509": "^2.9.4",
+        "@peculiar/asn1-x509-attr": "^2.9.4",
         "asn1js": "^3.0.10",
         "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@peculiar/asn1-rsa": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.8.0.tgz",
-      "integrity": "sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg==",
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.9.4.tgz",
+      "integrity": "sha512-pZ96eD1PptovcWQ/GSmuNFXd/7EQJNlKfDaNCyE2rx3W0v6QFelkzquVqRSRyyDXXCYD69ZXJDzZ8GhIiQzKoA==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.8.0",
-        "@peculiar/asn1-x509": "^2.8.0",
+        "@peculiar/asn1-schema": "^2.9.4",
+        "@peculiar/asn1-x509": "^2.9.4",
         "asn1js": "^3.0.10",
         "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@peculiar/asn1-schema": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
-      "integrity": "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==",
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.9.4.tgz",
+      "integrity": "sha512-GjzePcT9Iw8NzeOPf73iNS9xM+TBhd/FilAfP+RQGkTMQJTVWtytN3JHJACCjf/ABNau5S7mS3g+DcuxmRgYEg==",
       "license": "MIT",
       "dependencies": {
         "@peculiar/utils": "^2.0.2",
         "asn1js": "^3.0.10",
         "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@peculiar/asn1-x509": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.8.0.tgz",
-      "integrity": "sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==",
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.9.4.tgz",
+      "integrity": "sha512-CxhBo/RdEbMMob7T31ZdQjGuoyRFLVwrDzTn25bihzBasRg9kRm/0IxIPvhgQtcK/9dNcO1XQL2fuPugwELL0Q==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-schema": "^2.9.4",
         "@peculiar/utils": "^2.0.2",
         "asn1js": "^3.0.10",
         "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@peculiar/asn1-x509-attr": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.8.0.tgz",
-      "integrity": "sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA==",
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.9.4.tgz",
+      "integrity": "sha512-ehQXbpQaQYycgu8OrvigwSPTFfVRcu0ECNYCWw+yzBp02Lw5paRqzzhUpfOgO2K38+WfFZuEz/0RPtam5g0OMg==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.8.0",
-        "@peculiar/asn1-x509": "^2.8.0",
+        "@peculiar/asn1-schema": "^2.9.4",
+        "@peculiar/asn1-x509": "^2.9.4",
         "asn1js": "^3.0.10",
         "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@peculiar/json-schema": {
@@ -6288,59 +6301,58 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@react-native/assets-registry": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.86.0.tgz",
-      "integrity": "sha512-nIaXbm2jX1OTYp0qbviJ3O6KZivoE8z3BnhUQ2LsqfZSWRoOK/n1qsiAr6oALiNKWnXY3j2KPwtYORnZzp8xew==",
+    "node_modules/@react-native/asset-utils": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@react-native/asset-utils/-/asset-utils-0.87.1.tgz",
+      "integrity": "sha512-FeFnbn9ENPs7IVBzZt1bBWfiRGvT4q+CsWwXGFyKVW/1ol3ylBRuTtXBGHIAmcNN4fUR60nSXsCN19pzNHkPgA==",
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": "^22.13.0 || ^24.3.0 || >= 26.0.0"
       }
     },
     "node_modules/@react-native/codegen": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.86.0.tgz",
-      "integrity": "sha512-uTs9DBo3+/lUqinsGZK0FKJRBVClrwMXoZToaDxE1Q2SL2e55vs2GwyZfIKzPl5uJnbu4PfFMIp0/mLXLWUMuA==",
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.87.1.tgz",
+      "integrity": "sha512-qbaqEdlUfj2vRgvWTpMoNgHnEqAhAYJLUrpGkb0WC9n0kdtqUvgigpz4bDktZwolM9BemXwgGFgyiAnbs3t0xw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/core": "^7.25.2",
         "@babel/parser": "^7.29.0",
-        "hermes-parser": "0.36.0",
+        "hermes-parser": "0.36.1",
         "invariant": "^2.2.4",
         "nullthrows": "^1.1.1",
         "tinyglobby": "^0.2.15",
         "yargs": "^17.6.2"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": "^22.13.0 || ^24.3.0 || >= 26.0.0"
       },
       "peerDependencies": {
         "@babel/core": "*"
       }
     },
     "node_modules/@react-native/community-cli-plugin": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.86.0.tgz",
-      "integrity": "sha512-Jv8p1ebEPfTzs8gmrjsdT2XMXFfeAg45Pman+XPLFGaSeGAZkutRFRyX9Cs9aGTSOyIA9YPJ6vDNb1ayTf1FKQ==",
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.87.1.tgz",
+      "integrity": "sha512-aGBae6v+ngy8fIpU1EOaVxn/8DOgmJNphEdn5Eb0wTchUCxr8bDjpTJYNdrptyn3qI/elk8r9agQ2OBaFvrRlw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@react-native/dev-middleware": "0.86.0",
+        "@react-native/asset-utils": "0.87.1",
+        "@react-native/dev-middleware": "0.87.1",
         "debug": "^4.4.0",
         "invariant": "^2.2.4",
-        "metro": "^0.84.3",
-        "metro-config": "^0.84.3",
-        "metro-core": "^0.84.3",
+        "metro": "^0.87.0",
         "semver": "^7.1.3"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": "^22.13.0 || ^24.3.0 || >= 26.0.0"
       },
       "peerDependencies": {
         "@react-native-community/cli": "*",
-        "@react-native/metro-config": "0.86.0"
+        "@react-native/metro-config": "0.87.1"
       },
       "peerDependenciesMeta": {
         "@react-native-community/cli": {
@@ -6377,19 +6389,19 @@
       "peer": true
     },
     "node_modules/@react-native/debugger-frontend": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.86.0.tgz",
-      "integrity": "sha512-7Mb3nDfyJeys+ELF75Ageu7VKERlnIMoO+aNPoXqTXvz+b41L6l2CqMyLpDHxkBSlenij6gEepPNgaIyWHbJZw==",
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.87.1.tgz",
+      "integrity": "sha512-RNm7soJB+8YSauLnsCCylA1eVfT6JWaDTPUEF01uu9YwDyZ7remKlZbXtmVbtscbNGcp+hbI4iZUdVOpQWsHuA==",
       "license": "BSD-3-Clause",
       "peer": true,
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": "^22.13.0 || ^24.3.0 || >= 26.0.0"
       }
     },
     "node_modules/@react-native/debugger-shell": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@react-native/debugger-shell/-/debugger-shell-0.86.0.tgz",
-      "integrity": "sha512-Y0zEkZzLz8ou6o/VLml1A31X/rMgc6DRjwxwzPMa94qRTMY070WeBCNTITQo4kKTBAUgbxh07oXPQqp0Tpja8w==",
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-shell/-/debugger-shell-0.87.1.tgz",
+      "integrity": "sha512-eNbKjcnseJIjy5XCDwyhKOT1ngOg3Dv1fVxTDtnVFqdqjqsbfY4v9JuJG1RZJ7+mFoRRe05HE8GSQU8B7n5xwQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6398,7 +6410,7 @@
         "fb-dotslash": "0.5.8"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": "^22.13.0 || ^24.3.0 || >= 26.0.0"
       }
     },
     "node_modules/@react-native/debugger-shell/node_modules/debug": {
@@ -6427,15 +6439,15 @@
       "peer": true
     },
     "node_modules/@react-native/dev-middleware": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.86.0.tgz",
-      "integrity": "sha512-20pTO6yTybmvXvro520H6C7jydIQnLKOl5qFtVEcHSdFrY63r3OGei+Rx9bILgSRmH6jgnfEcijcMx7pwWuQtw==",
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.87.1.tgz",
+      "integrity": "sha512-KgvAGUaVl6/XrWFAPK8e0ojDRbsdBjr4bnwyn6PC3CwxPQc5iv+i7hMoUwYS8ORSkHKfjt+cV86/mBQ4lG8yfA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@isaacs/ttlcache": "^1.4.1",
-        "@react-native/debugger-frontend": "0.86.0",
-        "@react-native/debugger-shell": "0.86.0",
+        "@react-native/debugger-frontend": "0.87.1",
+        "@react-native/debugger-shell": "0.87.1",
         "chrome-launcher": "^0.15.2",
         "chromium-edge-launcher": "^0.3.0",
         "connect": "^3.6.5",
@@ -6447,7 +6459,7 @@
         "ws": "^7.5.10"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": "^22.13.0 || ^24.3.0 || >= 26.0.0"
       }
     },
     "node_modules/@react-native/dev-middleware/node_modules/debug": {
@@ -6476,9 +6488,9 @@
       "peer": true
     },
     "node_modules/@react-native/dev-middleware/node_modules/ws": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
-      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -6498,36 +6510,26 @@
       }
     },
     "node_modules/@react-native/gradle-plugin": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.86.0.tgz",
-      "integrity": "sha512-a1RcfaEDqWExCGfCwadIxt4l8FvKYgFqeMf2uzeKyAOnb+vTGNIeCvifFL2MqvgaeYxlER437HbMIajGcuJ1pQ==",
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.87.1.tgz",
+      "integrity": "sha512-bZ5X2BNxaSlfp2KlDtUM910QqW9G1yTIeZXghuv4ag8SAQLzm5Mf9j5GjJfT6ax2Qo2aRT15Vi3Tro/yLGJstA==",
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
-      }
-    },
-    "node_modules/@react-native/js-polyfills": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.86.0.tgz",
-      "integrity": "sha512-zYy/Cjd1VTnZ2iCNaG9bDF9C3l2ntESiPRscjIlI5FKugu6aeTwsDSv1aI8Bc4Kp3vEdoVg+UQhLAhE4svREaQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": "^22.13.0 || ^24.3.0 || >= 26.0.0"
       }
     },
     "node_modules/@react-native/normalize-colors": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.86.0.tgz",
-      "integrity": "sha512-kG0wfCGghUKlfxkJyyHCDVutWVYWK7/DG58ojA/4v9EfulgF+osuSQmlbNb3rcKX58qutm7JcldSeVLgGFha9g==",
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.87.1.tgz",
+      "integrity": "sha512-8+AutemzX+a7cuKgTUyb7JUk3sFYgLyrSnlTLrL6LuW/LKDE+FYE8lJGWYhJPJcE51Ge1D8yRzxgQEdEFZtuIw==",
       "license": "MIT",
       "peer": true
     },
     "node_modules/@react-native/virtualized-lists": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.86.0.tgz",
-      "integrity": "sha512-4/ZLXdf/OSpPDVO0AsQ1SJdRIzt5t9BNQ46QwGgxvX7/cirYR5k8KXctNGGgW8lQo2gZChEfY2zFCZg9nM/jiw==",
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.87.1.tgz",
+      "integrity": "sha512-qSZjeX3UJrDvyfjf7yc3E68rp1XnzE+5nu8ImklhkVC0+p/XiaHPb/KGkRqDdnQyWHN55BRYSsCMEwgVI6WRNQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6535,12 +6537,12 @@
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": "^22.13.0 || ^24.3.0 || >= 26.0.0"
       },
       "peerDependencies": {
         "@types/react": "^19.2.0",
         "react": "*",
-        "react-native": "0.86.0"
+        "react-native": "0.87.1"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -6549,9 +6551,9 @@
       }
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "version": "0.27.12",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.12.tgz",
+      "integrity": "sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g==",
       "license": "MIT",
       "peer": true
     },
@@ -6620,9 +6622,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
-      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "version": "26.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.1.tgz",
+      "integrity": "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -6674,19 +6676,6 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
     },
     "node_modules/abort-error": {
       "version": "1.0.2",
@@ -6747,9 +6736,9 @@
       "license": "MIT"
     },
     "node_modules/acorn": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "license": "MIT",
       "peer": true,
       "bin": {
@@ -6845,25 +6834,25 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
-      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.20.0.tgz",
+      "integrity": "sha512-r8aOh8j9cGKpgQAqpzrUHnSIc6a59Y3Xf/cv8sy1DrHCkZHzQGEuoq1tARk6qSyDdtQGSDgpb9kFlruzPvrgwg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
+        "form-data": "^4.0.6",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-plugin-syntax-hermes-parser": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.36.0.tgz",
-      "integrity": "sha512-LhD0xdoedDw7ansQgXbB2DADLZIK/LRXuWNBPuVzMc5S2WK5GyT89tCM+cQzxFGO0mGyLK6D5TrVOJJzAoDy8Q==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.36.1.tgz",
+      "integrity": "sha512-ycduwJbvdvIMmVvlAZqGggS+pm5Eu4Bk9pcV9Sm2Z4PJNRVsKkv0g7vHj+LeuC1gHTeF67sJXFOq61IlqCa2hA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "hermes-parser": "0.36.0"
+        "hermes-parser": "0.36.1"
       }
     },
     "node_modules/base64-js": {
@@ -6887,9 +6876,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.42",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
-      "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
+      "version": "2.11.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
+      "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -6968,9 +6957,9 @@
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/browserslist": {
-      "version": "4.28.5",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.5.tgz",
-      "integrity": "sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "funding": [
         {
           "type": "opencollective",
@@ -6988,11 +6977,11 @@
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.42",
-        "caniuse-lite": "^1.0.30001800",
-        "electron-to-chromium": "^1.5.387",
-        "node-releases": "^2.0.50",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -7094,9 +7083,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001803",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001803.tgz",
-      "integrity": "sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "funding": [
         {
           "type": "opencollective",
@@ -7548,9 +7537,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.389",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
-      "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
+      "version": "1.5.420",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.420.tgz",
+      "integrity": "sha512-2yD6XreGusOfNV+dUcvipJEXc3n/n7fgr7996aszTG+YY5E4mqM4tOq/3uhP129cazL9YHbVWSpc79ePotWtPA==",
       "license": "ISC",
       "peer": true
     },
@@ -7683,16 +7672,6 @@
       "resolved": "https://registry.npmjs.org/event-iterator/-/event-iterator-2.0.0.tgz",
       "integrity": "sha512-KGft0ldl31BZVV//jj+IAIGCxkvvUkkON+ScH6zfoX+l+omX6001ggyRSpI0Io2Hlro0ThXotswCtfzS8UkIiQ==",
       "license": "MIT"
-    },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
@@ -8110,9 +8089,9 @@
       }
     },
     "node_modules/helia/node_modules/@chainsafe/as-sha256": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@chainsafe/as-sha256/-/as-sha256-1.2.4.tgz",
-      "integrity": "sha512-3GXDysZOKD6cTYbm48lEdXdUbS7cafjXQZfgHOspTByhoGR/JM3KBXyF3vE6bf63ImjNPyoEZwnQcpYPQ6k3bQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@chainsafe/as-sha256/-/as-sha256-1.2.5.tgz",
+      "integrity": "sha512-8LzmWxBC/2O5BgbP+aRom/FaDJMrM04VZMlVIivYTc6yNQKYrONmIv27m3q/1VBgxrfrNNqmibitb2hE2tQzIw==",
       "license": "Apache-2.0"
     },
     "node_modules/helia/node_modules/@chainsafe/libp2p-noise": {
@@ -8141,12 +8120,12 @@
       }
     },
     "node_modules/helia/node_modules/@libp2p/crypto": {
-      "version": "5.1.21",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.21.tgz",
-      "integrity": "sha512-GipsBinthJuk7DpwthTUixZHSaKogcxm2glPCP0VkYkEpzZrfEvBEekRvlP5+1Ak8pReaHcz4gPKFA9X6MG0WQ==",
+      "version": "5.1.23",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.23.tgz",
+      "integrity": "sha512-u6XVMD1YpUJgjS5MAayrxlzi+hQcj3FHY0wS6/M/T93ntyCW13BmmRzFb2ESamk65PEuSCAChmQeSzRV2sh2rQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^3.2.5",
+        "@libp2p/interface": "^3.3.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "multiformats": "^14.0.0",
@@ -8156,9 +8135,9 @@
       }
     },
     "node_modules/helia/node_modules/@libp2p/crypto/node_modules/@libp2p/interface": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.5.tgz",
-      "integrity": "sha512-RdTchTdakBBc4ShKKsvoME/bJYsrCoVDpdYQVdd4TQ30TCb8QwWKGClqAtw7gfLNuaUKm41xz06kASW6AZpbDA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.3.0.tgz",
+      "integrity": "sha512-SXahM/4IgpiFKTtocbXYSTA1wEUVjktmT1yBCzBbc2Vgsu1VBCg6SvsFmXo2Hbeyev3D8EU+y3uaCKDB43C/Vg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@multiformats/dns": "^1.0.6",
@@ -8182,12 +8161,12 @@
       }
     },
     "node_modules/helia/node_modules/@libp2p/crypto/node_modules/@noble/curves": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
-      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.4.0.tgz",
+      "integrity": "sha512-P4/62zrgfH33CneE3Dn4WhJVA22YUU0eR51wKIan4NVRvwsA0YnPTwWGpNbpuacSujmSFLvyzpyuR30+fbq2Ew==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "2.2.0"
+        "@noble/hashes": "2.4.0"
       },
       "engines": {
         "node": ">= 20.19.0"
@@ -8197,9 +8176,9 @@
       }
     },
     "node_modules/helia/node_modules/@libp2p/crypto/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -8209,9 +8188,9 @@
       }
     },
     "node_modules/helia/node_modules/@libp2p/crypto/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/helia/node_modules/@libp2p/crypto/node_modules/protons-runtime": {
@@ -8354,28 +8333,43 @@
         "uint8arraylist": "^2.4.8"
       }
     },
+    "node_modules/helia/node_modules/p-event": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-6.0.1.tgz",
+      "integrity": "sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-timeout": "^6.1.2"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/hermes-compiler": {
-      "version": "250829098.0.14",
-      "resolved": "https://registry.npmjs.org/hermes-compiler/-/hermes-compiler-250829098.0.14.tgz",
-      "integrity": "sha512-5meXwsZxgiqFaJjNzwjzI9IyUkuGGBisu+z9BvQWmGVpjH6nz11hgqkyxe4dl8UAdyIV4lTbz91+Dlnjz0VxqA==",
+      "version": "250829098.0.17",
+      "resolved": "https://registry.npmjs.org/hermes-compiler/-/hermes-compiler-250829098.0.17.tgz",
+      "integrity": "sha512-qG1PXzTEtriF6oQLZF3vyHhSMxOdW5h2TqqLri0rdpstPustd2fSvRZQMVAPdlhgFwBfYnj3OUZtiO6LjYsEFw==",
       "license": "MIT",
       "peer": true
     },
     "node_modules/hermes-estree": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.36.0.tgz",
-      "integrity": "sha512-A1+8zn5oss2CFP7pKsOaxorQG6FNIz1WU1VDqruLPPZl3LVgeE2C5xfFg8Ow6/Ow4mSslLLtYP1J3n38eKyW9w==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.36.1.tgz",
+      "integrity": "sha512-guv1nQ6IJ7S83NRFPWc3SA7IBZrdNC9kapwOq6uXvF4wP+sDCgjzQbKPCoyYmoyZRzztF/n/c36l/rccCZSiCw==",
       "license": "MIT",
       "peer": true
     },
     "node_modules/hermes-parser": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.36.0.tgz",
-      "integrity": "sha512-GdpwMmH5x6IpC1cijvcvYnlPB60Mh6kTSF/NFdYV/j56gYdi+0RIakYs+eqOV+bbO0SW7mgVVGSsTJxyPQfo3w==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.36.1.tgz",
+      "integrity": "sha512-GApNk4zLHi2UWoWZZkx7LNCOSzLSc5lB55pZ/PhK7ycFeg7u5LcF88p/WbpIi1XUDtE0MpHE3uRR3u3KB7TjSQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "hermes-estree": "0.36.0"
+        "hermes-estree": "0.36.1"
       }
     },
     "node_modules/http-cookie-agent": {
@@ -8503,19 +8497,17 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/image-size": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
-      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
+      "name": "image-size-next",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/image-size-next/-/image-size-next-2.1.1.tgz",
+      "integrity": "sha512-n+DFjUct+G9mxZck+lvzqrTsqBJvSHMs6iEo//W5iAgRV7oUbrh1JWmKgAEpmyRB5lw6plIQizS1wK1dvrsvAw==",
       "license": "MIT",
       "peer": true,
-      "dependencies": {
-        "queue": "6.0.2"
-      },
       "bin": {
-        "image-size": "bin/image-size.js"
+        "image-size-next": "bin/image-size-next.js"
       },
       "engines": {
-        "node": ">=16.x"
+        "node": ">=18"
       }
     },
     "node_modules/inherits": {
@@ -8616,12 +8608,12 @@
       }
     },
     "node_modules/ipns/node_modules/@libp2p/crypto": {
-      "version": "5.1.21",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.21.tgz",
-      "integrity": "sha512-GipsBinthJuk7DpwthTUixZHSaKogcxm2glPCP0VkYkEpzZrfEvBEekRvlP5+1Ak8pReaHcz4gPKFA9X6MG0WQ==",
+      "version": "5.1.23",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.23.tgz",
+      "integrity": "sha512-u6XVMD1YpUJgjS5MAayrxlzi+hQcj3FHY0wS6/M/T93ntyCW13BmmRzFb2ESamk65PEuSCAChmQeSzRV2sh2rQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^3.2.5",
+        "@libp2p/interface": "^3.3.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "multiformats": "^14.0.0",
@@ -8631,9 +8623,9 @@
       }
     },
     "node_modules/ipns/node_modules/@libp2p/crypto/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/ipns/node_modules/@libp2p/crypto/node_modules/protons-runtime": {
@@ -8676,9 +8668,9 @@
       }
     },
     "node_modules/ipns/node_modules/@libp2p/interface": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.5.tgz",
-      "integrity": "sha512-RdTchTdakBBc4ShKKsvoME/bJYsrCoVDpdYQVdd4TQ30TCb8QwWKGClqAtw7gfLNuaUKm41xz06kASW6AZpbDA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.3.0.tgz",
+      "integrity": "sha512-SXahM/4IgpiFKTtocbXYSTA1wEUVjktmT1yBCzBbc2Vgsu1VBCg6SvsFmXo2Hbeyev3D8EU+y3uaCKDB43C/Vg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@multiformats/dns": "^1.0.6",
@@ -8690,9 +8682,9 @@
       }
     },
     "node_modules/ipns/node_modules/@libp2p/interface/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/ipns/node_modules/@libp2p/interface/node_modules/uint8arraylist": {
@@ -8714,12 +8706,12 @@
       }
     },
     "node_modules/ipns/node_modules/@libp2p/logger": {
-      "version": "6.2.10",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-6.2.10.tgz",
-      "integrity": "sha512-recRqNABHG32YXvpMvNepFCuU14d51dF5hs+vR2C/tkqXBQc0Sqg5LtWB2NYPoIJV+JUB50iWLrvBXZUOjLc9Q==",
+      "version": "6.2.13",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-6.2.13.tgz",
+      "integrity": "sha512-+tkZuRPoiFdh+frG//3hQ3goV1uMzRblpZ+mwtezgLXkRNqB5YKBLl+c/rtrurwAUqjCuI/yoEPJBiCizg2z6w==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^3.2.5",
+        "@libp2p/interface": "^3.3.0",
         "@multiformats/multiaddr": "^13.0.3",
         "interface-datastore": "^10.0.1",
         "multiformats": "^14.0.0",
@@ -8747,9 +8739,9 @@
       }
     },
     "node_modules/ipns/node_modules/@libp2p/logger/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/ipns/node_modules/@libp2p/logger/node_modules/uint8arrays": {
@@ -8774,9 +8766,9 @@
       }
     },
     "node_modules/ipns/node_modules/@multiformats/multiaddr/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/ipns/node_modules/@multiformats/multiaddr/node_modules/uint8-varint": {
@@ -8808,12 +8800,12 @@
       }
     },
     "node_modules/ipns/node_modules/@noble/curves": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
-      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.4.0.tgz",
+      "integrity": "sha512-P4/62zrgfH33CneE3Dn4WhJVA22YUU0eR51wKIan4NVRvwsA0YnPTwWGpNbpuacSujmSFLvyzpyuR30+fbq2Ew==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "2.2.0"
+        "@noble/hashes": "2.4.0"
       },
       "engines": {
         "node": ">= 20.19.0"
@@ -8823,9 +8815,9 @@
       }
     },
     "node_modules/ipns/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -8835,9 +8827,9 @@
       }
     },
     "node_modules/ipns/node_modules/cborg": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-5.1.7.tgz",
-      "integrity": "sha512-rGg2MG9zZEUKtKqjkBppIWUecTXf9N1vs1Qru43vJWoDaODhCrtmzdehCaA/aq/c1cPI5A0kPrJ5Tf+jIfhV4w==",
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-5.1.11.tgz",
+      "integrity": "sha512-oc6Pzg/gkTobxHZNgMmny+G99dOeBMbAmnGHcZWMKtolxZBIVwfi0Pj0khxEtNU8HMFdbT5sK0HmtgecDUPP0A==",
       "license": "Apache-2.0",
       "bin": {
         "cborg": "lib/bin.js"
@@ -8919,9 +8911,9 @@
       }
     },
     "node_modules/is-loopback-addr": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-loopback-addr/-/is-loopback-addr-2.0.2.tgz",
-      "integrity": "sha512-26POf2KRCno/KTNL5Q0b/9TYnL00xEsSaLfiFRmjM7m7Lw7ZMmFybzzuX4CcsLAluZGd+niLUiMRxEooVE3aqg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-loopback-addr/-/is-loopback-addr-2.1.0.tgz",
+      "integrity": "sha512-77bB59Coq+vGTibZlnuYVU1bUuiboGZ62ZJ7TqmgYKb+hko9dSlqS5OfqvmPZhwJys48At4y4D1UJP3GuvoXtQ==",
       "license": "MIT"
     },
     "node_modules/is-network-error": {
@@ -9010,9 +9002,9 @@
       }
     },
     "node_modules/it-byte-stream/node_modules/race-signal": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/race-signal/-/race-signal-2.0.0.tgz",
-      "integrity": "sha512-P31bLhE4ByBX/70QDXMutxnqgwrF1WUXea1O8DXuviAgkdbQ1iQMQotNgzJIBC9yUSn08u/acZrMUhgw7w6GpA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/race-signal/-/race-signal-2.0.2.tgz",
+      "integrity": "sha512-IuNNNY5NLriMFEGl3BVei2xq9NIcpkuAklhPWamhu5tRJrJz0w9sloUMz73YXpmUluE2EZocmJm9rpQqXmCPiA==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/it-drain": {
@@ -9111,9 +9103,9 @@
       }
     },
     "node_modules/it-merge": {
-      "version": "3.0.14",
-      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-3.0.14.tgz",
-      "integrity": "sha512-D3t1Go2G2SQMkTujaA6EVojJPJKA9pFksxlSPDRBfrHKhWl6O40vEP7Itr5eCAjyCQH5p9+BFFVIy9bhLM4ZuQ==",
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-3.0.15.tgz",
+      "integrity": "sha512-rUskoyECUdJsUwpfBtiLXddm56J+vukMztq+PpfTss1mRl/aHv1YJs+6Q2XnpvDThFC2y4Xm636X0xh6IecPGg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "it-queueless-pushable": "^2.0.0"
@@ -9220,9 +9212,9 @@
       }
     },
     "node_modules/it-queue/node_modules/race-signal": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/race-signal/-/race-signal-2.0.0.tgz",
-      "integrity": "sha512-P31bLhE4ByBX/70QDXMutxnqgwrF1WUXea1O8DXuviAgkdbQ1iQMQotNgzJIBC9yUSn08u/acZrMUhgw7w6GpA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/race-signal/-/race-signal-2.0.2.tgz",
+      "integrity": "sha512-IuNNNY5NLriMFEGl3BVei2xq9NIcpkuAklhPWamhu5tRJrJz0w9sloUMz73YXpmUluE2EZocmJm9rpQqXmCPiA==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/it-queueless-pushable": {
@@ -9237,9 +9229,9 @@
       }
     },
     "node_modules/it-queueless-pushable/node_modules/race-signal": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/race-signal/-/race-signal-2.0.0.tgz",
-      "integrity": "sha512-P31bLhE4ByBX/70QDXMutxnqgwrF1WUXea1O8DXuviAgkdbQ1iQMQotNgzJIBC9yUSn08u/acZrMUhgw7w6GpA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/race-signal/-/race-signal-2.0.2.tgz",
+      "integrity": "sha512-IuNNNY5NLriMFEGl3BVei2xq9NIcpkuAklhPWamhu5tRJrJz0w9sloUMz73YXpmUluE2EZocmJm9rpQqXmCPiA==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/it-reader": {
@@ -9459,12 +9451,12 @@
       }
     },
     "node_modules/libp2p/node_modules/@libp2p/crypto": {
-      "version": "5.1.21",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.21.tgz",
-      "integrity": "sha512-GipsBinthJuk7DpwthTUixZHSaKogcxm2glPCP0VkYkEpzZrfEvBEekRvlP5+1Ak8pReaHcz4gPKFA9X6MG0WQ==",
+      "version": "5.1.23",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.23.tgz",
+      "integrity": "sha512-u6XVMD1YpUJgjS5MAayrxlzi+hQcj3FHY0wS6/M/T93ntyCW13BmmRzFb2ESamk65PEuSCAChmQeSzRV2sh2rQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^3.2.5",
+        "@libp2p/interface": "^3.3.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "multiformats": "^14.0.0",
@@ -9474,9 +9466,9 @@
       }
     },
     "node_modules/libp2p/node_modules/@libp2p/crypto/node_modules/@libp2p/interface": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.5.tgz",
-      "integrity": "sha512-RdTchTdakBBc4ShKKsvoME/bJYsrCoVDpdYQVdd4TQ30TCb8QwWKGClqAtw7gfLNuaUKm41xz06kASW6AZpbDA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.3.0.tgz",
+      "integrity": "sha512-SXahM/4IgpiFKTtocbXYSTA1wEUVjktmT1yBCzBbc2Vgsu1VBCg6SvsFmXo2Hbeyev3D8EU+y3uaCKDB43C/Vg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@multiformats/dns": "^1.0.6",
@@ -9500,9 +9492,9 @@
       }
     },
     "node_modules/libp2p/node_modules/@libp2p/crypto/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/libp2p/node_modules/@libp2p/crypto/node_modules/uint8arraylist": {
@@ -9552,12 +9544,12 @@
       }
     },
     "node_modules/libp2p/node_modules/@noble/curves": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
-      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.4.0.tgz",
+      "integrity": "sha512-P4/62zrgfH33CneE3Dn4WhJVA22YUU0eR51wKIan4NVRvwsA0YnPTwWGpNbpuacSujmSFLvyzpyuR30+fbq2Ew==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "2.2.0"
+        "@noble/hashes": "2.4.0"
       },
       "engines": {
         "node": ">= 20.19.0"
@@ -9567,9 +9559,9 @@
       }
     },
     "node_modules/libp2p/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -9590,9 +9582,9 @@
       }
     },
     "node_modules/libp2p/node_modules/protons-runtime/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/libp2p/node_modules/protons-runtime/node_modules/uint8arraylist": {
@@ -9624,9 +9616,9 @@
       }
     },
     "node_modules/libp2p/node_modules/uint8-varint/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/libp2p/node_modules/uint8-varint/node_modules/uint8arraylist": {
@@ -9689,9 +9681,9 @@
       }
     },
     "node_modules/main-event": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/main-event/-/main-event-1.0.4.tgz",
-      "integrity": "sha512-sKazUjIy2Jalv5lkQ446iOcrx8Q7TkaCuk6xfnzg5uUqMusMLDMPmRDmSNE2kjSVpSTJo4j1bQZusS+Ib7Bvrg==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/main-event/-/main-event-1.0.5.tgz",
+      "integrity": "sha512-4l9z8r7Q446mhhVTwdHmfPksOYBwN2xa7ewEW2yxPVNQapIaAf57ORFLMB91SpMEMa4wXowect7fq3uMLjDnGA==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/makeerror": {
@@ -9783,9 +9775,9 @@
       }
     },
     "node_modules/metro": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro/-/metro-0.84.4.tgz",
-      "integrity": "sha512-8ETTubqfD6ornDy2zYDvRcKnVDOXdFJsjetYDBsY4oAsb6NJkiwFR+FaMESyGppFmQUyBQA4H4sFGxzcQSGtFA==",
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/metro/-/metro-0.87.0.tgz",
+      "integrity": "sha512-fRqFhSzQhLNQSCvJFeuRzBRXAOOKXf1O8d2cvmMtG6yFR0jCllQ7vBsXoLP18yuqtf+N1XwWXTPF11eWy9q6dQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -9803,24 +9795,24 @@
         "error-stack-parser": "^2.0.6",
         "flow-enums-runtime": "^0.0.6",
         "graceful-fs": "^4.2.4",
-        "hermes-parser": "0.35.0",
+        "hermes-parser": "0.36.1",
         "image-size": "^1.0.2",
         "invariant": "^2.2.4",
         "jest-worker": "^29.7.0",
         "jsc-safe-url": "^0.2.2",
         "lodash.throttle": "^4.1.1",
-        "metro-babel-transformer": "0.84.4",
-        "metro-cache": "0.84.4",
-        "metro-cache-key": "0.84.4",
-        "metro-config": "0.84.4",
-        "metro-core": "0.84.4",
-        "metro-file-map": "0.84.4",
-        "metro-resolver": "0.84.4",
-        "metro-runtime": "0.84.4",
-        "metro-source-map": "0.84.4",
-        "metro-symbolicate": "0.84.4",
-        "metro-transform-plugins": "0.84.4",
-        "metro-transform-worker": "0.84.4",
+        "metro-babel-transformer": "0.87.0",
+        "metro-cache": "0.87.0",
+        "metro-cache-key": "0.87.0",
+        "metro-config": "0.87.0",
+        "metro-core": "0.87.0",
+        "metro-file-map": "0.87.0",
+        "metro-resolver": "0.87.0",
+        "metro-runtime": "0.87.0",
+        "metro-source-map": "0.87.0",
+        "metro-symbolicate": "0.87.0",
+        "metro-transform-plugins": "0.87.0",
+        "metro-transform-worker": "0.87.0",
         "mime-types": "^3.0.1",
         "nullthrows": "^1.1.1",
         "serialize-error": "^2.1.0",
@@ -9833,70 +9825,53 @@
         "metro": "src/cli.js"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": "^22.13.0 || ^24.3.0 || >= 26.0.0"
       }
     },
     "node_modules/metro-babel-transformer": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.84.4.tgz",
-      "integrity": "sha512-rvCfz8snl9h20VcvpOHxZuHP1SlAkv4HXbzw7nyyVwu6Eqo5PRerbakQ9XmUCOsRy70spJ37O+G1TK8oMzo48g==",
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.87.0.tgz",
+      "integrity": "sha512-IEn1K1FyY4J1sA5y6zqDjf2OkfmpTEqhZOeP6MJX8HepSW0cuHGw1m8bYOdv2adkG3XUE9dtM0csUs0gP/Xa5w==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/core": "^7.25.2",
         "flow-enums-runtime": "^0.0.6",
-        "hermes-parser": "0.35.0",
-        "metro-cache-key": "0.84.4",
+        "hermes-parser": "0.36.1",
+        "metro-cache-key": "0.87.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
-      }
-    },
-    "node_modules/metro-babel-transformer/node_modules/hermes-estree": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.35.0.tgz",
-      "integrity": "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/metro-babel-transformer/node_modules/hermes-parser": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.35.0.tgz",
-      "integrity": "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "hermes-estree": "0.35.0"
+        "node": "^22.13.0 || ^24.3.0 || >= 26.0.0"
       }
     },
     "node_modules/metro-cache": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.84.4.tgz",
-      "integrity": "sha512-gpcFQdSLUwUCk71saKoE64jLFbx2nwTfVCcPSULMNT8QYq0p1eZZE29Jvd0HtT/UlhC3ZOutLxJME5xqD2JUZg==",
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.87.0.tgz",
+      "integrity": "sha512-146vS1BMSKcp99jddOhFBfHwzUEWN35NrsnSJDF2sQQ0ZT5OsBcOjd574PM233TWEZISRJ5DOK+vokD+1ubx+w==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "exponential-backoff": "^3.1.1",
         "flow-enums-runtime": "^0.0.6",
         "https-proxy-agent": "^7.0.5",
-        "metro-core": "0.84.4"
+        "metro-core": "0.87.0"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": "^22.13.0 || ^24.3.0 || >= 26.0.0"
       }
     },
     "node_modules/metro-cache-key": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.84.4.tgz",
-      "integrity": "sha512-wVO79aGrkYImpnaVS4+d5RrRBRPX31QtvKB3wKGBuiNSznduZTQHzsrJZRroFJSwnygrzdsGUtDQPuqqFjFdvw==",
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.87.0.tgz",
+      "integrity": "sha512-Q+MPt6jl0zQogr4Q02WaJK6HY+GtE5A0nzj8kIV1Owgrx6OMNvm6scPTr1SM/R4LpCE8EH/Y5qfbXQ84GHTr0Q==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": "^22.13.0 || ^24.3.0 || >= 26.0.0"
       }
     },
     "node_modules/metro-cache/node_modules/debug": {
@@ -9939,44 +9914,43 @@
       "peer": true
     },
     "node_modules/metro-config": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.84.4.tgz",
-      "integrity": "sha512-PMotGDjXcXLWo2TMRH+VR99phFNgYTwqh4OoieIKK3yTJa1Jmkl+fZJxDO0jfBvNF+WESHciHvpNuBtXaF3B0Q==",
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.87.0.tgz",
+      "integrity": "sha512-yZ9QAIzWH9MxwrzwRlX/CBGRWOT14l7klSDYg8hdtSdnoUs5A7MQRdHE2KB9iHVzGQW5wgWM5aXJswNeWbSQPA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "connect": "^3.6.5",
         "flow-enums-runtime": "^0.0.6",
         "jest-validate": "^29.7.0",
-        "metro": "0.84.4",
-        "metro-cache": "0.84.4",
-        "metro-core": "0.84.4",
-        "metro-runtime": "0.84.4",
-        "yaml": "^2.6.1"
+        "metro": "0.87.0",
+        "metro-cache": "0.87.0",
+        "metro-core": "0.87.0",
+        "metro-runtime": "0.87.0"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": "^22.13.0 || ^24.3.0 || >= 26.0.0"
       }
     },
     "node_modules/metro-core": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.84.4.tgz",
-      "integrity": "sha512-HONpWC5LGXZn3ffkd4Hu6AIrfE7j4Z0g0wMo/goV24WOB3lhuFZ40KgvaDiSw8iyQHloMYay5N/wPX+z8oN/PQ==",
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.87.0.tgz",
+      "integrity": "sha512-yW57+pCOHRC/CJZ99GA2PTd+30dORwDAjUPRCokj91IWW5In9Jwtt2FB5wACrGO8P0GHTyVHdTwDNyZsNndUbA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
         "lodash.throttle": "^4.1.1",
-        "metro-resolver": "0.84.4"
+        "metro-resolver": "0.87.0"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": "^22.13.0 || ^24.3.0 || >= 26.0.0"
       }
     },
     "node_modules/metro-file-map": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.84.4.tgz",
-      "integrity": "sha512-KSVDi/u60hKPx++NLu3MTIvyjzNoJnFAF8PQFxaj1jiSka/wjw+Ua6sNuJ0TDHQv+7AAoFQxeMgaRAe8Yic5wQ==",
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.87.0.tgz",
+      "integrity": "sha512-Dc57t8jsINwA90bbVlqaeDlxf1rVGgj5SmOEnOMbaHNUM/HCYYTJxPV8SRdOBwh7qTz/biO9vaQvBTjRBgbbsg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -9991,7 +9965,7 @@
         "walker": "^1.0.7"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": "^22.13.0 || ^24.3.0 || >= 26.0.0"
       }
     },
     "node_modules/metro-file-map/node_modules/debug": {
@@ -10020,9 +9994,9 @@
       "peer": true
     },
     "node_modules/metro-minify-terser": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.84.4.tgz",
-      "integrity": "sha512-5qpbaVOMC7CPitIpuewzVeGw7E+C3ykbv2mqTjQLl85Z3annSVGlSCTcsZjqXZzjupfK4Ztj3dDc4kc44NZwtQ==",
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.87.0.tgz",
+      "integrity": "sha512-tPa0O983PDutFu3LXbArRH5NduogcKrvW6fs9VHhksTKUA1iqDyoD1ZSj/Me52xJ6T9/9pOwIVyj9ulKc/zMkg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -10030,26 +10004,26 @@
         "terser": "^5.15.0"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": "^22.13.0 || ^24.3.0 || >= 26.0.0"
       }
     },
     "node_modules/metro-resolver": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.84.4.tgz",
-      "integrity": "sha512-1qLgbxQ5ZGhhutuPot1Yp348ofDsATL2WkrHF65TobqTT9K3P9qJXw38bomk7ncp5B7OYMfWwtyBZo1lCV792A==",
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.87.0.tgz",
+      "integrity": "sha512-Xl3M9R3KToaHJvXlI2lSOxtYHitzxite+195DSi00HL9PcS7Xik5+3xlRjfkKb3FA86SZxYPj+WJwlcfgaZoxg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": "^22.13.0 || ^24.3.0 || >= 26.0.0"
       }
     },
     "node_modules/metro-runtime": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.84.4.tgz",
-      "integrity": "sha512-Jibypds4g7AhzdRKY+kDoj51s5EXMwgyp5ddtlreDAsWefMdOx+agWqgm0H2XSZ/ueanHHVM89fnf5OJnlxa8Q==",
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.87.0.tgz",
+      "integrity": "sha512-XsXZkgEwI0ZMYSBfvOMAbenzwa60XlObXJ27g6/Khgrz9ESbiBbAsd7hR62G2jRBYOhGAzG61Gk22dpRJj/mdw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -10057,13 +10031,13 @@
         "flow-enums-runtime": "^0.0.6"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": "^22.13.0 || ^24.3.0 || >= 26.0.0"
       }
     },
     "node_modules/metro-source-map": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.84.4.tgz",
-      "integrity": "sha512-jbWkPxIesVuo1IWkvezmMJld6iu8nD62GsrZiV6jP37AOdbo4OBq1FJ+qkOg8sV05wAHB//jAbziuW0SlJfW4g==",
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.87.0.tgz",
+      "integrity": "sha512-31BrYqu1c2co93rF1LN9Pw+7g+BrfDyxJkNQWrYm+pfA/+eVYVumF7tFMHbXLePLmHfhvSgVvbK6su1Oyiw1ng==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -10071,26 +10045,26 @@
         "@babel/types": "^7.29.0",
         "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-symbolicate": "0.84.4",
+        "metro-symbolicate": "0.87.0",
         "nullthrows": "^1.1.1",
-        "ob1": "0.84.4",
+        "ob1": "0.87.0",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": "^22.13.0 || ^24.3.0 || >= 26.0.0"
       }
     },
     "node_modules/metro-symbolicate": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.84.4.tgz",
-      "integrity": "sha512-OnfpacxUqGPZQ27t8qK9mFa7uqHIlVWeqRqkCbvMvreEBiamEeOn8krKtcwgP5M4cYDPwuSmCTopHMVthqG4zA==",
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.87.0.tgz",
+      "integrity": "sha512-uOpTxAXu74N+RSujUZ78L6gjI6bDdnz6XuW+AIUNuubZDEQPIpaX0StzIb0GMeQWP6zfHOHwFrWPP5Iquu1GXw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-source-map": "0.84.4",
+        "metro-source-map": "0.87.0",
         "nullthrows": "^1.1.1",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
@@ -10099,13 +10073,13 @@
         "metro-symbolicate": "src/index.js"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": "^22.13.0 || ^24.3.0 || >= 26.0.0"
       }
     },
     "node_modules/metro-transform-plugins": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.84.4.tgz",
-      "integrity": "sha512-kehr6HbAecqD0/a3xLXobELdPaAmRAl8bel0qagPF4vhZtux93nS8S4eq2kgKt6J2GnQpVjSoW1PXdst04mwow==",
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.87.0.tgz",
+      "integrity": "sha512-i8keUe9+BaSwMuQM26DGheElCpTtflAKIrSwJAm8ZsgDb50RAUQus+e6zt2suaJXJ1OxZa7vqgtqoZxdniM6Fw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -10117,13 +10091,13 @@
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": "^22.13.0 || ^24.3.0 || >= 26.0.0"
       }
     },
     "node_modules/metro-transform-worker": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.84.4.tgz",
-      "integrity": "sha512-W1IYMvvXTu4MxYr7d9h7CeG2vpIr3bmLLIavkPY4O1ilzDrvS8z/NEe6y+pC44Ff7raMXQgYSfdqDUwN/i39gg==",
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.87.0.tgz",
+      "integrity": "sha512-YftLzNJxCTYxEN5k4AzR8KYwiENTEuz30L+4QeoMrtDd+U8mDThZg/ArR3JVRd8LaikwPOjVAS5SP3xPJN0AaA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -10132,17 +10106,17 @@
         "@babel/parser": "^7.29.0",
         "@babel/types": "^7.29.0",
         "flow-enums-runtime": "^0.0.6",
-        "metro": "0.84.4",
-        "metro-babel-transformer": "0.84.4",
-        "metro-cache": "0.84.4",
-        "metro-cache-key": "0.84.4",
-        "metro-minify-terser": "0.84.4",
-        "metro-source-map": "0.84.4",
-        "metro-transform-plugins": "0.84.4",
+        "metro": "0.87.0",
+        "metro-babel-transformer": "0.87.0",
+        "metro-cache": "0.87.0",
+        "metro-cache-key": "0.87.0",
+        "metro-minify-terser": "0.87.0",
+        "metro-source-map": "0.87.0",
+        "metro-transform-plugins": "0.87.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": "^22.13.0 || ^24.3.0 || >= 26.0.0"
       }
     },
     "node_modules/metro/node_modules/accepts": {
@@ -10157,6 +10131,20 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/metro/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/metro/node_modules/debug": {
@@ -10175,23 +10163,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/metro/node_modules/hermes-estree": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.35.0.tgz",
-      "integrity": "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/metro/node_modules/hermes-parser": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.35.0.tgz",
-      "integrity": "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "hermes-estree": "0.35.0"
       }
     },
     "node_modules/metro/node_modules/mime-db": {
@@ -10229,19 +10200,26 @@
       "peer": true
     },
     "node_modules/metro/node_modules/negotiator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
+      "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
       "license": "MIT",
       "peer": true,
+      "dependencies": {
+        "content-type": "^2.1.0"
+      },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/metro/node_modules/ws": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
-      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -10435,9 +10413,9 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "3.94.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
-      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+      "version": "3.96.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.96.0.tgz",
+      "integrity": "sha512-rebQ/lz7i0EkoLzUVSrKRzA69zMkwLp95kKMWoMDkkM00Suxz0D7zEQPwRml5fQum24mj7bPvmlgLAmu2JCiYg==",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
@@ -10463,9 +10441,9 @@
       "peer": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.50",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
-      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -10480,16 +10458,16 @@
       "peer": true
     },
     "node_modules/ob1": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.84.4.tgz",
-      "integrity": "sha512-eJXMpz4aQHXF/YBB9ddqZDIS+ooO91hObo9FoW/xBkr54/zCwYYCDqT/O54vNo8kOkWs5Ou/y28NgdrV0edQNA==",
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.87.0.tgz",
+      "integrity": "sha512-8Q8sKCiUwsxgSmjDtVWyRgmxsgeJXXam3oQH6Id8ADfNaJMV6GZKyeAl8+pGVVdgwAZabfk5+aExle7AP/nZiA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": "^22.13.0 || ^24.3.0 || >= 26.0.0"
       }
     },
     "node_modules/object-inspect": {
@@ -10555,15 +10533,27 @@
       }
     },
     "node_modules/p-event": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/p-event/-/p-event-6.0.1.tgz",
-      "integrity": "sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-7.1.0.tgz",
+      "integrity": "sha512-/lkPs5W1aC3cp6vqZefpdosOn65J571sWodyfOQiF0+tmDCpU+H8Atwpu0vQROCVUlZuToDN5eyTLsMLLc54mg==",
       "license": "MIT",
       "dependencies": {
-        "p-timeout": "^6.1.2"
+        "p-timeout": "^7.0.1"
       },
       "engines": {
-        "node": ">=16.17"
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-event/node_modules/p-timeout": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -10798,9 +10788,9 @@
       }
     },
     "node_modules/pvutils": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
-      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.2.0.tgz",
+      "integrity": "sha512-BbubeCEyTuQjVMakvJQ/Sxbc93F2pwmbsxONT/ZRrwU7Ua38d8unYTwXpTVLAKJ4BDuH9IGztCjQcd/N/39Dvg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
@@ -10820,16 +10810,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/queue": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
-      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "inherits": "~2.0.3"
       }
     },
     "node_modules/race-event": {
@@ -10899,9 +10879,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -10920,9 +10900,9 @@
       }
     },
     "node_modules/react-devtools-core/node_modules/ws": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
-      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -10949,31 +10929,29 @@
       "peer": true
     },
     "node_modules/react-native": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.86.0.tgz",
-      "integrity": "sha512-17ALh/dd6AO4pgOVmOO5Axll5PbErEo3XFyLokyzW6usyi+OShIEPwUW26wLPlhVifgSOIfECCH0WN+0IqtJ1w==",
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.87.1.tgz",
+      "integrity": "sha512-DJKG6ANoD7BtrE4z9DewiSD7/RxCX73lK5Pu49aUr85P3333Dm2roTiP0rRjQNDZdVizHSOmstWfwF/o9EjCRA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@react-native/assets-registry": "0.86.0",
-        "@react-native/codegen": "0.86.0",
-        "@react-native/community-cli-plugin": "0.86.0",
-        "@react-native/gradle-plugin": "0.86.0",
-        "@react-native/js-polyfills": "0.86.0",
-        "@react-native/normalize-colors": "0.86.0",
-        "@react-native/virtualized-lists": "0.86.0",
-        "abort-controller": "^3.0.0",
+        "@react-native/asset-utils": "0.87.1",
+        "@react-native/codegen": "0.87.1",
+        "@react-native/community-cli-plugin": "0.87.1",
+        "@react-native/gradle-plugin": "0.87.1",
+        "@react-native/normalize-colors": "0.87.1",
+        "@react-native/virtualized-lists": "0.87.1",
         "anser": "^1.4.9",
         "ansi-regex": "^5.0.0",
-        "babel-plugin-syntax-hermes-parser": "0.36.0",
+        "babel-plugin-syntax-hermes-parser": "0.36.1",
         "base64-js": "^1.5.1",
         "commander": "^12.0.0",
         "flow-enums-runtime": "^0.0.6",
-        "hermes-compiler": "250829098.0.14",
+        "hermes-compiler": "250829098.0.17",
         "invariant": "^2.2.4",
         "memoize-one": "^5.0.0",
-        "metro-runtime": "^0.84.3",
-        "metro-source-map": "^0.84.3",
+        "metro-runtime": "^0.87.0",
+        "metro-source-map": "^0.87.0",
         "nullthrows": "^1.1.1",
         "pretty-format": "^29.7.0",
         "promise": "^8.3.0",
@@ -10992,31 +10970,26 @@
         "react-native": "cli.js"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": "^22.13.0 || ^24.3.0 || >= 26.0.0"
       },
       "peerDependencies": {
-        "@react-native/jest-preset": "0.86.0",
         "@types/react": "^19.1.1",
         "react": "^19.2.3"
       },
       "peerDependenciesMeta": {
-        "@react-native/jest-preset": {
-          "optional": true
-        },
         "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/react-native-webrtc": {
-      "version": "124.0.7",
-      "resolved": "https://registry.npmjs.org/react-native-webrtc/-/react-native-webrtc-124.0.7.tgz",
-      "integrity": "sha512-gnXPdbUS8IkKHq9WNaWptW/yy5s6nMyI6cNn90LXdobPVCgYSk6NA2uUGdT4c4J14BRgaFA95F+cR28tUPkMVA==",
+      "version": "124.0.8",
+      "resolved": "https://registry.npmjs.org/react-native-webrtc/-/react-native-webrtc-124.0.8.tgz",
+      "integrity": "sha512-uuQxvmk+mvnk5U0tr+1N42sKZqgm41fJrBA+fmCvML9J9P4roSh2So82t5RHAlu/vE9vxu5AKgivAiH61clCBg==",
       "license": "MIT",
       "dependencies": {
         "base64-js": "1.5.1",
-        "debug": "4.3.4",
-        "event-target-shim": "6.0.2"
+        "debug": "4.3.4"
       },
       "peerDependencies": {
         "react-native": ">=0.60.0"
@@ -11039,18 +11012,6 @@
         }
       }
     },
-    "node_modules/react-native-webrtc/node_modules/event-target-shim": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
-      "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      }
-    },
     "node_modules/react-native-webrtc/node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -11058,9 +11019,9 @@
       "license": "MIT"
     },
     "node_modules/react-native/node_modules/ws": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
-      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -11177,9 +11138,9 @@
       }
     },
     "node_modules/sax": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
-      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -11289,9 +11250,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
-      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -11595,9 +11556,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.49.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.0.tgz",
-      "integrity": "sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==",
+      "version": "5.51.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.51.2.tgz",
+      "integrity": "sha512-bWnjSNscmuI+GJze6ZupnHP8G/cTcsJF+bXCeQknk2SHQsgbNJnLrqiH9jZ2W4STPVXH2mDKKRX3iwPhc9Cn/Q==",
       "license": "BSD-2-Clause",
       "peer": true,
       "dependencies": {
@@ -11693,9 +11654,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -11897,9 +11858,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "funding": [
         {
           "type": "opencollective",
@@ -12091,9 +12052,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -12155,22 +12116,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC",
       "peer": true
-    },
-    "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "license": "ISC",
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.3",

--- a/test/interop/helia/package.json
+++ b/test/interop/helia/package.json
@@ -24,6 +24,7 @@
     "libp2p": "^2.0.0"
   },
   "overrides": {
-    "@libp2p/kad-dht": "^16.3.4"
+    "@libp2p/kad-dht": "^16.3.4",
+    "image-size": "npm:image-size-next@2.1.1"
   }
 }


### PR DESCRIPTION
## Summary
- image-size <= 2.0.2 has two high-severity DoS CVEs (CVE-2025-71329, CVE-2025-71330) with no upstream fix published
- The community-maintained fork image-size-next@2.1.1 is a drop-in replacement based on upstream 2.0.2 with both infinite-loop vulnerabilities fixed
- Uses npm package aliasing so all transitive consumers (metro -> react-native) get the patched version
- Applied to test/interop/helia where image-size is pulled transitively
- npm audit: 0 vulnerabilities

#### Test plan
- [x] npm install succeeds
- [x] npm audit reports 0 vulnerabilities
- [x] image-size-next@2.1.1 resolves correctly in dependency tree